### PR TITLE
Fix segmentation fault when SSL_get_server_tmp_key returns 0

### DIFF
--- a/usual/tls/tls_util.c
+++ b/usual/tls/tls_util.c
@@ -194,8 +194,8 @@ tls_get_connection_info(struct tls *ctx, char *buf, size_t buflen)
 		if (ctx->flags & TLS_CLIENT) {
 			EVP_PKEY *pk = NULL;
 			int ok = SSL_get_server_tmp_key(conn, &pk);
-			int pk_type = EVP_PKEY_id(pk);
-			if (ok && pk) {
+			if (ok) {
+				int pk_type = EVP_PKEY_id(pk);
 				if (pk_type == EVP_PKEY_DH) {
 					DH *dh = EVP_PKEY_get0(pk);
 					used_dh_bits = DH_size(dh) * 8;


### PR DESCRIPTION
I noticed that for certain key handshakes in my installation (I haven't determined exactly what makes them special), pgbouncer reliably segfaults in tls_get_connection_info. libusual was calling EVP_PKEY_id with pk = 0, and EVP_PKEY_id assumes a non-null argument.

Recompiled with this fix, pgbouncer does not segfault under the same code path. I believe the proposed patch makes correct use of the libssl API, but I admit I'm not too well versed in using it.
