### PR TITLE
Warnings

### DIFF
--- a/usual/talloc.c
+++ b/usual/talloc.c
@@ -1217,7 +1217,12 @@ char *talloc_vasprintf(const void *parent, const char *fmt, va_list ap)
 
 char *talloc_vasprintf_append(char *ptr, const char *fmt, va_list ap)
 {
-	size_t plen = strnlen(ptr, talloc_get_size(ptr));
+	size_t plen;
+
+	if (ptr == NULL)
+		return NULL;
+
+	plen = strnlen(ptr, talloc_get_size(ptr));
 	return _tprintf(NULL, ptr, plen, fmt, ap);
 }
 

--- a/usual/tls/tls_conninfo.c
+++ b/usual/tls/tls_conninfo.c
@@ -62,6 +62,9 @@ tls_get_peer_cert_hash(struct tls *ctx, char **hash)
 	unsigned int dlen;
 	int rv = -1;
 
+	if (hash == NULL)
+		return (-1);
+
 	*hash = NULL;
 	if (ctx->ssl_peer_cert == NULL)
 		return (0);

--- a/usual/tls/tls_ocsp.c
+++ b/usual/tls/tls_ocsp.c
@@ -904,7 +904,7 @@ static int
 tls_ocsp_common_query(struct tls **ocsp_ctx_p, int *fd_p, struct tls_config *config, struct tls *target)
 {
 	struct tls *ctx = NULL;
-	int ret, fd;
+	int ret, fd = -1;
 
 	/* async path */
 	if (fd_p)

--- a/usual/tls/tls_ocsp.c
+++ b/usual/tls/tls_ocsp.c
@@ -561,6 +561,9 @@ tls_ocsp_setup(struct tls **ocsp_ctx_p, struct tls_config *config, struct tls *t
 		q->cert_ssl_ctx = ctx->ssl_ctx;
 		SSL_CTX_get_extra_chain_certs(ctx->ssl_ctx, &q->extra_certs);
 	} else {
+		if (!target)
+			return -1;
+
 		/* steal state from target struct */
 		q->main_cert = SSL_get_peer_certificate(target->ssl_conn);
 		q->extra_certs = SSL_get_peer_cert_chain(target->ssl_conn);

--- a/usual/tls/tls_ocsp.c
+++ b/usual/tls/tls_ocsp.c
@@ -539,7 +539,7 @@ tls_ocsp_setup(struct tls **ocsp_ctx_p, struct tls_config *config, struct tls *t
 {
 	struct tls *ctx;
 	struct tls_ocsp_query *q;
-	int ret;
+	int ret = -1;
 	STACK_OF(OPENSSL_STRING) *ocsp_urls;
 
 	ctx = tls_ocsp_client_new();


### PR DESCRIPTION
Fixes some uses of uninitialized values and NULL pointer dereferences pickedup by clang's scan-build.