### PR TITLE
Determine CA file at runtime instead of build time

### DIFF
--- a/m4/usual.m4
+++ b/m4/usual.m4
@@ -412,7 +412,7 @@ if test "$tls_support" = "auto" -o "$tls_support" = "libssl"; then
   LIBS="$tmp_LIBS"
 
   dnl Pick default root CA file
-  cafile=auto
+  cafile=
   AC_MSG_CHECKING([for root CA certs])
   AC_ARG_WITH(root-ca-file,
     AC_HELP_STRING([--with-root-ca-file=FILE], [specify where the root CA certificates are]),
@@ -424,14 +424,9 @@ if test "$tls_support" = "auto" -o "$tls_support" = "libssl"; then
         cafile="$withval"
       fi
     ])
-  if test "$cafile" = "auto"; then
-    for cafile in /etc/ssl/certs/ca-certificates.crt /etc/ssl/cert.pem; do
-      if test -f "$cafile"; then
-        break
-      fi
-    done
+  if test -n "$cafile"; then
+    AC_DEFINE_UNQUOTED(USUAL_TLS_CA_FILE, ["$cafile"], [Path to root CA certs.])
   fi
-  AC_DEFINE_UNQUOTED(USUAL_TLS_CA_FILE, ["$cafile"], [Path to root CA certs.])
   AC_MSG_RESULT([$cafile])
 else
   AC_MSG_RESULT([no])

--- a/usual/tls/tls_internal.h
+++ b/usual/tls/tls_internal.h
@@ -23,8 +23,6 @@
 
 #include <usual/socket.h>
 
-#define _PATH_SSL_CA_FILE USUAL_TLS_CA_FILE
-
 /*
  * Anything that is not completely broken.
  *


### PR DESCRIPTION
Previously, this meant that building on a system with its CA file in one location and running on a system with a different location would fail to verify certificates.

Instead, construct a list of certificates (which may include the provided `--with-root-ca-file` argument) and iterate over that at runtime, taking the first one that exists and is a regular file, with fallback to `/etc/ssl/cert.pem` as with the previous build-time check.

This has the following results:

 1. If the user does not provide `--with-root-ca-file`, the behaviour is the same as before, but suited to the running system rather than the build system.

 2. If the user does provide `--with-root-ca-file`, and the provided file exists, it will always be used, as before.

 3. If the user provides `--with-root-ca-file`, and the provided file does not exist on the running system, libusual will fall back to the built-in defaults.

Point 3 above is the only change that might break existing usage, if the user creates their provided CA file after starting their program. If they absolutely need to use a specific CA file, then they should instead call `tls_config_set_ca_file()` from their program, rather than relying on libusual configuration.