### PR TITLE
cfparser: Log an error when config file could not be loaded

### DIFF
--- a/usual/cfparser.c
+++ b/usual/cfparser.c
@@ -53,8 +53,10 @@ static bool parse_ini_file_internal(const char *fn, cf_handler_f user_handler, v
 	bool ok;
 
 	buf = load_file(fn, NULL);
-	if (buf == NULL)
+	if (buf == NULL) {
+		log_error("could not load file \"%s\": %s", fn, strerror(errno));
 		return false;
+	}
 
 	p = buf;
 	while (*p) {
@@ -87,8 +89,10 @@ static bool parse_ini_file_internal(const char *fn, cf_handler_f user_handler, v
 			log_debug("processing include: %s", val);
 			ok = parse_ini_file_internal(val, user_handler, arg, inclevel + 1);
 			val[vlen] = o1;
-			if (!ok)
+			if (!ok) {
+				log_error("error processing include file in configuration (%s:%d), stopping loading", fn, count_lines(buf, p));
 				goto failed;
+			}
 			log_debug("returned to processing file %s", fn);
 			continue;
 		}

--- a/usual/fileutil.c
+++ b/usual/fileutil.c
@@ -36,6 +36,7 @@ void *load_file(const char *fn, size_t *len_p)
 	char *buf = NULL;
 	int res;
 	FILE *f;
+	int save_errno;
 
 	f = fopen(fn, "r");
 	if (!f)
@@ -43,19 +44,25 @@ void *load_file(const char *fn, size_t *len_p)
 
 	res = fstat(fileno(f), &st);
 	if (res < 0) {
+		save_errno = errno;
 		fclose(f);
+		errno = save_errno;
 		return NULL;
 	}
 
 	buf = malloc(st.st_size + 1);
 	if (!buf) {
+		save_errno = errno;
 		fclose(f);
+		errno = save_errno;
 		return NULL;
 	}
 
 	if ((res = fread(buf, 1, st.st_size, f)) < 0) {
+		save_errno = errno;
 		free(buf);
 		fclose(f);
+		errno = save_errno;
 		return NULL;
 	}
 


### PR DESCRIPTION
In particular, when the file could not be opened or on some other I/O
error, print the operating system error.  Also, when failing to load
an include file, print the location where the include directive was.

closes pgbouncer/pgbouncer#584, closes pgbouncer/pgbouncer#592