### PR TITLE
CI: Use new MacOS instance

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -134,14 +134,13 @@ task:
 
 task:
   name: macOS
-  osx_instance:
-    matrix:
-      - image: monterey-base
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
   setup_script:
     - brew install autoconf automake libevent libtool openssl pkg-config
   env:
-    CPPFLAGS: -I/usr/local/opt/openssl/include
-    LDFLAGS: -L/usr/local/opt/openssl/lib
+    CPPFLAGS: -I/opt/homebrew/opt/openssl@3/include
+    LDFLAGS: -L/opt/homebrew/opt/openssl@3/lib
   build_script:
     - ./autogen.sh
     - ./configure --prefix=$HOME/install --enable-werror


### PR DESCRIPTION
Message from Cirrus: "Intel macOS instances are no longer supported!"

same as pgbouncer/pgbouncer@8fc50f6