### PR TITLE
Stop relying on TLS cipher settings from 2009 OpenBSD

### DIFF
--- a/usual/tls/tls_compat.c
+++ b/usual/tls/tls_compat.c
@@ -44,13 +44,6 @@
  * https://tools.ietf.org/html/draft-ietf-ipsec-skip-06
  */
 
-static const char file_dh1024[] =
-"-----BEGIN DH PARAMETERS-----\n"
-"MIGHAoGBAPSI/VhOSdvNILSd5JEHNmszbDgNRR0PfIizHHxbLY7288kjwEPwpVsY\n"
-"jY67VYy4XTjTNP18F1dDox0YbN4zISy1Kv884bEpQBgRjXyEpwpy1obEAxnIByl6\n"
-"ypUM2Zafq9AKUJsCRtMIPWakXUGfnHy9iUsiGSa6q6Jew1XpL3jHAgEC\n"
-"-----END DH PARAMETERS-----\n";
-
 static const char file_dh2048[] =
 "-----BEGIN DH PARAMETERS-----\n"
 "MIIBCAKCAQEA9kJXtwh/CBdyorrWqULzBej5UxE5T7bxbrlLOCDaAadWoxTpj0BV\n"
@@ -77,7 +70,7 @@ static const char file_dh4096[] =
 "-----END DH PARAMETERS-----\n";
 
 
-static DH *dh1024, *dh2048, *dh4096;
+static DH *dh2048, *dh4096;
 
 static DH *load_dh_buffer(struct tls *ctx, DH **dhp, const char *buf)
 {
@@ -109,23 +102,13 @@ static DH *dh_auto_cb(SSL *s, int is_export, int keylength)
 	bits = EVP_PKEY_bits(pk);
 	if (bits >= 3072)
 		return load_dh_buffer(ctx, &dh4096, file_dh4096);
-	if (bits >= 1536)
-		return load_dh_buffer(ctx, &dh2048, file_dh2048);
-	return load_dh_buffer(ctx, &dh1024, file_dh1024);
-}
-
-static DH *dh_legacy_cb(SSL *s, int is_export, int keylength)
-{
-	struct tls *ctx = SSL_get_app_data(s);
-	return load_dh_buffer(ctx, &dh1024, file_dh1024);
+	return load_dh_buffer(ctx, &dh2048, file_dh2048);
 }
 
 long SSL_CTX_set_dh_auto(SSL_CTX *ctx, int onoff)
 {
-	if (onoff == 0)
+	if (onoff == 0) {
 		return 1;
-	if (onoff == 2) {
-		SSL_CTX_set_tmp_dh_callback(ctx, dh_legacy_cb);
 	} else {
 		SSL_CTX_set_tmp_dh_callback(ctx, dh_auto_cb);
 	}
@@ -199,7 +182,6 @@ long SSL_CTX_set_ecdh_auto(SSL_CTX *ctx, int onoff)
 void tls_compat_cleanup(void)
 {
 #ifdef DH_CLEANUP
-	if (dh1024) { DH_free(dh1024); dh1024 = NULL; }
 	if (dh2048) { DH_free(dh2048); dh2048 = NULL; }
 	if (dh4096) { DH_free(dh4096); dh4096 = NULL; }
 #endif

--- a/usual/tls/tls_internal.h
+++ b/usual/tls/tls_internal.h
@@ -25,41 +25,6 @@
 
 #define _PATH_SSL_CA_FILE USUAL_TLS_CA_FILE
 
-/*
- * Anything that is not completely broken.
- *
- * Also fixes 3DES ordering bug in older OpenSSLs.
- */
-#define TLS_CIPHERS_COMPAT	"HIGH:+3DES:!aNULL"
-
-/*
- * All==insecure.
- */
-#define TLS_CIPHERS_ALL		"ALL:!aNULL:!eNULL"
-
-/*
- * TLSv1.2+AEAD+ECDHE/DHE.  CBC modes are dubious due to spec bugs in TLS.
- */
-#define TLS_CIPHERS_DEFAULT	"HIGH+EECDH:HIGH+EDH:!SSLv3:!SHA384:!SHA256:!DSS:!aNULL"
-
-/*
- * Compact subset of reasonable suites only.
- *
- * Priorities, in order:
- * - ECDHE > DHE > RSA
- * - AESGCM > CBC
- * - TLSv1.2 > TLSv1.0
- * - AES256 > AES128.
- */
-#define TLS_CIPHERS_NORMAL	"HIGH+EECDH:HIGH+EDH:HIGH+RSA:+SHA384:+SHA256:+SSLv3:+EDH:+RSA:-3DES:3DES+RSA:!CAMELLIA:!DSS:!aNULL"
-
-/*
- * Prefer performance if it does not affect security.
- *
- * Same as "normal" but prefers AES128 to AES256.
- */
-#define TLS_CIPHERS_FAST	"HIGH+EECDH:HIGH+EDH:HIGH+RSA:+AES256:+SHA256:+SHA384:+SSLv3:+EDH:+RSA:-3DES:3DES+RSA:!CAMELLIA:!DSS:!aNULL"
-
 union tls_addr {
 	struct in_addr ip4;
 	struct in6_addr ip6;

--- a/usual/tls/tls_ocsp.c
+++ b/usual/tls/tls_ocsp.c
@@ -767,7 +767,6 @@ tls_ocsp_connection_setup(struct tls *ctx)
 
 		SSL_CTX_set_options(q->ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
 		SSL_CTX_clear_options(q->ssl_ctx, SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2 | SSL_OP_NO_TLSv1_3);
-		SSL_CTX_set_cipher_list(q->ssl_ctx, TLS_CIPHERS_COMPAT);
 		SSL_CTX_set_mode(q->ssl_ctx, SSL_MODE_AUTO_RETRY);
 
 		q->bio = BIO_new_ssl_connect(q->ssl_ctx);

--- a/usual/tls/tls_server.c
+++ b/usual/tls/tls_server.c
@@ -77,8 +77,6 @@ tls_configure_server(struct tls *ctx)
 
 	if (ctx->config->dheparams == -1)
 		SSL_CTX_set_dh_auto(ctx->ssl_ctx, 1);
-	else if (ctx->config->dheparams == 1024)
-		SSL_CTX_set_dh_auto(ctx->ssl_ctx, 2);
 
 	if (ctx->config->ecdhecurve == -1) {
 		SSL_CTX_set_ecdh_auto(ctx->ssl_ctx, 1);


### PR DESCRIPTION
- Change the keywords secure, normal and fast to mean default, as their concepts were 10 years out of date. This ensures old configs will migrate from (now) insecure configs to modern openssl secure defaults.
- Remove "legacy" and "insecure" keyword from TLS ciphers as these are meaningless and not stable over 15 years of staleness.
- Remove "legacy" keyword for DH that supported DH1024 which is not secure.
- For default, do not call SSL_CTX_set_cipher_list() so it uses the openssl defaults. In those systems with a system-wide crypto policy (Fedora, RHEL, CentOS and clones) this ensures conforming to those (eg "DEFAULT", "FUTURE", "FIPS", etc)
- For OCSP, no longer set some arcane TLS cipher with 3des, but use openssl/system defaults.
- Remove support for DHE 1024 for the TLS server, it is too weak.