### PR TITLE
Use OPENSSL_free for OpenSSL allocations to avoid crash

### DIFF
--- a/usual/tls/tls_compat.h
+++ b/usual/tls/tls_compat.h
@@ -117,6 +117,12 @@ int SSL_CTX_load_verify_mem(SSL_CTX *ctx, void *buf, int len);
 #define SSL_set_tlsext_status_type(a,b) (1)
 #endif
 
+/* AWS-LC does not currently have OCSP support */
+#if defined(OPENSSL_IS_AWSLC) && defined(OPENSSL_NO_OCSP)
+#define SSL_CTX_set_tlsext_status_cb(a,b) (1)
+#define SSL_set_tlsext_status_type(a,b) (1)
+#endif
+
 void tls_compat_cleanup(void);
 
 #ifndef SSL_OP_NO_TLSv1_3

--- a/usual/tls/tls_conninfo.c
+++ b/usual/tls/tls_conninfo.c
@@ -190,9 +190,9 @@ tls_free_conninfo(struct tls_conninfo *conninfo) {
 	if (conninfo != NULL) {
 		free(conninfo->hash);
 		conninfo->hash = NULL;
-		free(conninfo->subject);
+		OPENSSL_free(conninfo->subject);
 		conninfo->subject = NULL;
-		free(conninfo->issuer);
+		OPENSSL_free(conninfo->issuer);
 		conninfo->issuer = NULL;
 		free(conninfo->version);
 		conninfo->version = NULL;


### PR DESCRIPTION
## Description

OpenSSL functions, like `X509_NAME_oneline`, returns pointers to memory allocations created using `OPENSSL_malloc`. The documentation for OpenSSL hints that such allocations should be freed using `OPENSSL_free` and not the standard `free`. For example:
> OPENSSL_strdup(), OPENSSL_strndup() and OPENSSL_memdup() are like the equivalent C functions, except that memory is allocated by calling the OPENSSL_malloc() and should be released by calling OPENSSL_free().

In OpenSSL forks like BoringSSL and AWS-LC, `OPENSSL_malloc` returns a pointer that can't be freed by `free`, and when attempted will cause a panic:
```
#0  0x0000ffff8e367c9c in free () from /lib64/libc.so.6
#1  0x000000000043a168 in tls_free_conninfo (conninfo=0x272fbea0) at lib/usual/tls/tls_conninfo.c:193
#2  0x0000000000436dc4 in tls_reset (ctx=ctx@entry=0x272f4bb0) at lib/usual/tls/tls.c:519
#3  0x0000000000436e58 in tls_free (ctx=0x272f4bb0) at lib/usual/tls/tls.c:494
```

This PR updates `tls_free_conninfo` to properly free the issuer and subject information in order to improve compatibility with the OpenSSL forks.