### PR TITLE
CI: Update FreeBSD image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -112,7 +112,7 @@ task:
 task:
   name: FreeBSD
   freebsd_instance:
-    image_family: freebsd-13-1
+    image_family: freebsd-13-2
   setup_script:
     - pkg install -y autoconf automake gmake libevent libtool pkgconf
   env:


### PR DESCRIPTION
FreeBSD 13.1 will EOL in ~2 weeks. This updates CI to use 13.2 instead.
