### PR TITLE
Fix errors pointed out by static analyzer

### DIFF
--- a/usual/cbtree.c
+++ b/usual/cbtree.c
@@ -179,6 +179,8 @@ void *cbtree_lookup(struct CBTree *tree, const void *key, size_t klen)
 static struct Node *new_node(struct CBTree *tree)
 {
 	struct Node *node = cx_alloc(tree->cx, sizeof(*node));
+	if (!node)
+		return NULL;
 	memset(node, 0, sizeof(*node));
 	return node;
 }


### PR DESCRIPTION
A static analyzer found an error here -
> Return value of a function 'cx_alloc' is dereferenced at cbtree.c:182 without checking for NULL, but it is usually checked for this 

And in all other cases (16/17) the result of cx_alloc is NULL-checked