### PR TITLE
Fix name collision with OpenSSL 3.2.0

### DIFF
--- a/test/connect-tls.c
+++ b/test/connect-tls.c
@@ -157,7 +157,7 @@ int main(int argc, char *argv[])
 	res = tls_ocsp_check_peer(&ocsp, NULL, ctx);
 	if (ocsp) {
 		show_ocsp_info("OCSP responder", ocsp);
-		tls_free(ocsp);
+		usual_tls_free(ocsp);
 	} else if (res == TLS_NO_OCSP) {
 		printf("OCSP responder: No OCSP support in libtls\n");
 	}
@@ -165,7 +165,7 @@ int main(int argc, char *argv[])
 	if (0) test_context(ctx);
 
 	tls_close(ctx);
-	tls_free(ctx);
+	usual_tls_free(ctx);
 	tls_config_free(conf);
 	tls_cert_free(cert);
 

--- a/test/test_tls.c
+++ b/test/test_tls.c
@@ -52,8 +52,8 @@ static void free_worker(struct Worker *w)
 		return;
 	if (event_initialized(&w->ev))
 		event_del(&w->ev);
-	tls_free(w->ctx);
-	tls_free(w->base);
+	usual_tls_free(w->ctx);
+	usual_tls_free(w->base);
 	tls_config_free(w->config);
 	if (w->socket > 0)
 		close(w->socket);
@@ -318,7 +318,7 @@ static void worker_cb(evutil_socket_t fd, short flags, void *arg)
 			res = tls_close(w->ctx);
 		}
 		if (res == 0) {
-			tls_free(w->ctx);
+			usual_tls_free(w->ctx);
 			w->ctx = NULL;
 		} else if (res == TLS_WANT_POLLIN) {
 			wait_for_event(w, EV_READ);
@@ -326,7 +326,7 @@ static void worker_cb(evutil_socket_t fd, short flags, void *arg)
 			wait_for_event(w, EV_WRITE);
 		} else {
 			add_error(w, "close error: res=%d err=%s", res, tls_error(w->ctx));
-			tls_free(w->ctx);
+			usual_tls_free(w->ctx);
 			w->ctx = NULL;
 		}
 	}
@@ -1007,10 +1007,10 @@ static const char *run_time(const char *val)
 	err = tls_asn1_parse_time(ctx, &tmp, &t);
 	if (err) {
 		strlcpy(buf, tls_error(ctx), sizeof buf);
-		tls_free(ctx);
+		usual_tls_free(ctx);
 		return buf;
 	}
-	tls_free(ctx);
+	usual_tls_free(ctx);
 
 	tm = gmtime(&t);
 	if (!tm)

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -499,7 +499,7 @@ tls_configure_ssl_verify(struct tls *ctx, int verify)
 }
 
 void
-tls_free(struct tls *ctx)
+usual_tls_free(struct tls *ctx)
 {
 	if (ctx == NULL)
 		return;

--- a/usual/tls/tls.h
+++ b/usual/tls/tls.h
@@ -119,7 +119,7 @@ struct tls *tls_client(void);
 struct tls *tls_server(void);
 int tls_configure(struct tls *_ctx, struct tls_config *_config);
 void tls_reset(struct tls *_ctx);
-void tls_free(struct tls *_ctx);
+void usual_tls_free(struct tls *_ctx);
 
 int tls_accept_fds(struct tls *_ctx, struct tls **_cctx, int _fd_read,
     int _fd_write);

--- a/usual/tls/tls_compat.c
+++ b/usual/tls/tls_compat.c
@@ -474,7 +474,7 @@ struct tls *tls_client(void) { return NULL; }
 struct tls *tls_server(void) { return NULL; }
 int tls_configure(struct tls *_ctx, struct tls_config *_config) { return -1; }
 void tls_reset(struct tls *_ctx) {}
-void tls_free(struct tls *_ctx) {}
+void usual_tls_free(struct tls *_ctx) {}
 
 int tls_accept_fds(struct tls *_ctx, struct tls **_cctx, int _fd_read, int _fd_write) { return -1; }
 int tls_accept_socket(struct tls *_ctx, struct tls **_cctx, int _socket) { return -1; }

--- a/usual/tls/tls_ocsp.c
+++ b/usual/tls/tls_ocsp.c
@@ -467,7 +467,7 @@ tls_ocsp_client_new(void)
 
 	ctx->ocsp_query = calloc(1, sizeof (struct tls_ocsp_query));
 	if (!ctx->ocsp_query) {
-		tls_free(ctx);
+		usual_tls_free(ctx);
 		return NULL;
 	}
 	return ctx;
@@ -895,7 +895,7 @@ tls_ocsp_query_async(struct tls **ocsp_ctx_p, int *fd_p, struct tls_config *conf
 	}
 	return tls_ocsp_evloop(ctx, fd_p, config);
 failed:
-	tls_free(ctx);
+	usual_tls_free(ctx);
 	return -1;
 }
 

--- a/usual/tls/tls_server.c
+++ b/usual/tls/tls_server.c
@@ -160,7 +160,7 @@ tls_accept_fds(struct tls *ctx, struct tls **cctx, int fd_read, int fd_write)
 	return (0);
 
  err:
-	tls_free(conn_ctx);
+	usual_tls_free(conn_ctx);
 
 	*cctx = NULL;
 


### PR DESCRIPTION
When statically compiling OpenSSL 3.2.0 into PgBouncer its Windows
binary I ran into this error:
```
C:/tools/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:/tools/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../lib\libssl.a(libssl-lib-tls_common.obj):(.text+0x6f0): multiple definition of `tls_free'; .objs/pgbouncer/lib/usual/tls/tls.o:C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build/lib/usual/tls/tls.c:503: first defined here
```
The interesting part is:
```
multiple definition of `tls_free'
```

This changes the name of `tls_free` in libusual to `usual_tls_free` to
avoid this collision.
