### PR TITLE
Ignore certain GCC warnings in SHList test

### DIFF
--- a/test/test_shlist.c
+++ b/test/test_shlist.c
@@ -98,6 +98,12 @@ static const char *xdel(struct SHList *list, int v)
 	return xshow(list);
 }
 
+#if (defined __GNUC__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overread"
+#endif
+
 static void test_shlist(void *p)
 {
 	struct SHList rlist, *list = &rlist;
@@ -141,6 +147,9 @@ static void test_shlist(void *p)
 	int_check(shlist_empty(list), 1);
 end:;
 }
+#if (defined __GNUC__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic pop
+#endif
 
 static void test_shlist_remove(void *p)
 {


### PR DESCRIPTION
New versions of GCC warn about pointer magic that SHList is actively
exploiting. This ignores those warnings.

Obviously it would be better to fix the warnings, but afaict that would
require huge changes to SHList. Since SHList is not used by PgBouncer
the impact of this is quite small and its not worth the effort to fix
this at the moment. This change at least makes CI green again.
