### PR TITLE
antimake: split LangObjTarget rule

### DIFF
--- a/mk/antimake.mk
+++ b/mk/antimake.mk
@@ -477,7 +477,10 @@ endef
 # 1-tgt, 2-name, 3-srcext
 define LangObjTarget
 $(trace3)
-$$(OBJDIR)/$(1)/%$(OBJEXT) $$(OBJDIR)/$(1)/%.lo: %$(3)
+$$(OBJDIR)/$(1)/%$(OBJEXT): %$(3)
+	@$$(call MkDir,$$(dir $$@))
+	$$(AM_LANG_$(2)_COMPILE)
+$$(OBJDIR)/$(1)/%.lo: %$(3)
 	@$$(call MkDir,$$(dir $$@))
 	$$(AM_LANG_$(2)_COMPILE)
 endef


### PR DESCRIPTION
GNU make 4.4 started to show warning:

	warning: pattern recipe did not update peer target '...'

That is because make expects rule in form

	%.o %.lo: %.c

build both targets in one execution, which does happen when building .lo objects, but not when building .o objects.

But this dependency between .o<>.lo is unnecessary complexity, as no rule uses both .o and .lo of same object file as input.

Thus is is enough to duplicate the rule for both cases and let the target pick which one it wants to depend on.