### PR TITLE
The 1st argument of calloc should be 'nelem'.

### DIFF
--- a/usual/tls/tls_cert.c
+++ b/usual/tls/tls_cert.c
@@ -329,7 +329,7 @@ tls_cert_get_altnames(struct tls *ctx, struct tls_cert *cert, X509 *x509_cert)
 		goto out;
 	}
 
-	cert->subject_alt_names = calloc(sizeof (struct tls_cert_general_name), count);
+	cert->subject_alt_names = calloc(count, sizeof(struct tls_cert_general_name));
 	if (cert->subject_alt_names == NULL) {
 		tls_set_error(ctx, "calloc");
 		goto out;
@@ -588,7 +588,7 @@ tls_parse_cert(struct tls *ctx, struct tls_cert **cert_p, const char *fingerprin
 		return -1;
 	}
 
-	cert = calloc(sizeof *cert, 1);
+	cert = calloc(1, sizeof(*cert));
 	if (!cert) {
 		tls_set_error(ctx, "calloc");
 		goto failed;


### PR DESCRIPTION
The 1st argument of calloc is the number of elements of the array that we want to allocate space for[^1].  This patch is for fixing compilation errors for pgbouncer CI[^2].

[^1]: https://man7.org/linux/man-pages/man3/calloc.3p.html
[^2]: https://cirrus-ci.com/task/5497785724698624