### PR TITLE
Add function to compare TLS configs for equality

### DIFF
--- a/test/test_string.c
+++ b/test/test_string.c
@@ -103,6 +103,21 @@ static void test_strerror_r(void *p)
 	tt_assert(strlen(strerror_r(EINTR, buf, sizeof(buf))) != 0);
 end:;
 }
+/*
+ * strings_equal
+ */
+
+static void test_strings_equal(void *ptr)
+{
+	tt_assert(strings_equal("foo", "foo") == true);
+	tt_assert(strings_equal(NULL, NULL) == true);
+
+	tt_assert(strings_equal("foo", "bar") == false);
+	tt_assert(strings_equal("foo", NULL) == false);
+	tt_assert(strings_equal(NULL, "foo") == false);
+end:;
+}
+
 
 /*
  * memrchr
@@ -635,6 +650,7 @@ struct testcase_t string_tests[] = {
 	{ "strlcat", test_strlcat },
 	{ "strnlen", test_strnlen },
 	{ "strerror_r", test_strerror_r },
+	{ "strings_equal", test_strings_equal },
 	{ "memrchr", test_memrchr },
 	{ "memmem", test_memmem },
 	{ "mempbrk", test_mempbrk },

--- a/test/test_string.c
+++ b/test/test_string.c
@@ -104,17 +104,17 @@ static void test_strerror_r(void *p)
 end:;
 }
 /*
- * strings_equal
+ * strcmpeq
  */
 
-static void test_strings_equal(void *ptr)
+static void test_strcmpeq(void *ptr)
 {
-	tt_assert(strings_equal("foo", "foo") == true);
-	tt_assert(strings_equal(NULL, NULL) == true);
+	tt_assert(strcmpeq("foo", "foo") == true);
+	tt_assert(strcmpeq(NULL, NULL) == true);
 
-	tt_assert(strings_equal("foo", "bar") == false);
-	tt_assert(strings_equal("foo", NULL) == false);
-	tt_assert(strings_equal(NULL, "foo") == false);
+	tt_assert(strcmpeq("foo", "bar") == false);
+	tt_assert(strcmpeq("foo", NULL) == false);
+	tt_assert(strcmpeq(NULL, "foo") == false);
 end:;
 }
 
@@ -650,7 +650,7 @@ struct testcase_t string_tests[] = {
 	{ "strlcat", test_strlcat },
 	{ "strnlen", test_strnlen },
 	{ "strerror_r", test_strerror_r },
-	{ "strings_equal", test_strings_equal },
+	{ "strcmpeq", test_strcmpeq },
 	{ "memrchr", test_memrchr },
 	{ "memmem", test_memmem },
 	{ "mempbrk", test_mempbrk },

--- a/test/test_tls.c
+++ b/test/test_tls.c
@@ -609,7 +609,7 @@ static void test_tls_config_equal(void *z)
 end:;
 }
 
-static void test_keypair_list_equal(void *z)
+static void test_tls_keypair_list_equal(void *z)
 {
 	struct tls_keypair *kp1a, *kp1b, *kp2a, *kp2b;
 	kp1a = tls_keypair_new();
@@ -625,7 +625,7 @@ static void test_keypair_list_equal(void *z)
 	tls_keypair_set_cert_file(kp2a, "ssl/ca1_server1.crt");
 	tls_keypair_set_cert_file(kp2b, "ssl/different_ca1_server2.crt");
 
-	tt_assert(keypair_list_equal(kp1a, kp2a) == false);
+	tt_assert(tls_keypair_list_equal(kp1a, kp2a) == false);
 end:;
 }
 
@@ -1084,7 +1084,7 @@ struct testcase_t tls_tests[] = {
 	{ "cipher-nego", test_cipher_nego },
 	{ "cert-info", test_cert_info },
 	{ "tls_config_equal", test_tls_config_equal },
-	{ "keypair_list_equal", test_keypair_list_equal },
+	{ "tls_keypair_list_equal", test_tls_keypair_list_equal },
 	END_OF_TESTCASES,
 	{ "servername", test_servername },
 };

--- a/test/test_tls.c
+++ b/test/test_tls.c
@@ -594,6 +594,21 @@ end:
 #define COMPLEX1 "key=ssl/ca1_complex1.key", "cert=ssl/ca1_complex1.crt"
 #define COMPLEX2 "key=ssl/ca2_complex2.key", "cert=ssl/ca2_complex2.crt"
 
+static void test_tls_configs_equal(void *z)
+{
+	struct Worker *server = NULL;
+	struct Worker *server_unchanged = NULL;
+	struct Worker *server_changed = NULL;
+
+	str_check(create_worker(&server, true, SERVER1, NULL), "OK");
+	str_check(create_worker(&server_unchanged, true, SERVER1, NULL), "OK");
+	str_check(create_worker(&server_changed, true, SERVER2, NULL), "OK");
+
+	tt_assert(tls_configs_equal(server->config, server_unchanged->config) == true);
+	tt_assert(tls_configs_equal(server->config, server_changed->config) == false);
+end:;
+}
+
 static void test_verify(void *z)
 {
 	struct Worker *server = NULL, *client = NULL;
@@ -1048,6 +1063,7 @@ struct testcase_t tls_tests[] = {
 	{ "set-mem", test_set_mem },
 	{ "cipher-nego", test_cipher_nego },
 	{ "cert-info", test_cert_info },
+	{ "tls_configs_equal", test_tls_configs_equal },
 	END_OF_TESTCASES,
 	{ "servername", test_servername },
 };

--- a/test/test_tls.c
+++ b/test/test_tls.c
@@ -609,6 +609,26 @@ static void test_tls_config_equal(void *z)
 end:;
 }
 
+static void test_keypair_list_equal(void *z)
+{
+  struct tls_keypair *kp1a, *kp1b, *kp2a, *kp2b;
+  kp1a = tls_keypair_new();
+  kp1b = tls_keypair_new();
+  kp2a = tls_keypair_new();
+  kp2b = tls_keypair_new();
+
+  kp1a->next = kp1b;
+  kp2a->next = kp2b;
+
+  tls_keypair_set_cert_file(kp1a, "ssl/ca1_server1.crt");
+  tls_keypair_set_cert_file(kp1b, "ssl/ca1_server2.crt");
+  tls_keypair_set_cert_file(kp2a, "ssl/ca1_server1.crt");
+  tls_keypair_set_cert_file(kp2b, "ssl/different_ca1_server2.crt");
+
+  tt_assert(keypair_list_equal(kp1a, kp2a) == false);
+end:;
+}
+
 static void test_verify(void *z)
 {
 	struct Worker *server = NULL, *client = NULL;
@@ -1064,6 +1084,7 @@ struct testcase_t tls_tests[] = {
 	{ "cipher-nego", test_cipher_nego },
 	{ "cert-info", test_cert_info },
 	{ "tls_config_equal", test_tls_config_equal },
+	{ "keypair_list_equal", test_keypair_list_equal },
 	END_OF_TESTCASES,
 	{ "servername", test_servername },
 };

--- a/test/test_tls.c
+++ b/test/test_tls.c
@@ -611,21 +611,21 @@ end:;
 
 static void test_keypair_list_equal(void *z)
 {
-  struct tls_keypair *kp1a, *kp1b, *kp2a, *kp2b;
-  kp1a = tls_keypair_new();
-  kp1b = tls_keypair_new();
-  kp2a = tls_keypair_new();
-  kp2b = tls_keypair_new();
+	struct tls_keypair *kp1a, *kp1b, *kp2a, *kp2b;
+	kp1a = tls_keypair_new();
+	kp1b = tls_keypair_new();
+	kp2a = tls_keypair_new();
+	kp2b = tls_keypair_new();
 
-  kp1a->next = kp1b;
-  kp2a->next = kp2b;
+	kp1a->next = kp1b;
+	kp2a->next = kp2b;
 
-  tls_keypair_set_cert_file(kp1a, "ssl/ca1_server1.crt");
-  tls_keypair_set_cert_file(kp1b, "ssl/ca1_server2.crt");
-  tls_keypair_set_cert_file(kp2a, "ssl/ca1_server1.crt");
-  tls_keypair_set_cert_file(kp2b, "ssl/different_ca1_server2.crt");
+	tls_keypair_set_cert_file(kp1a, "ssl/ca1_server1.crt");
+	tls_keypair_set_cert_file(kp1b, "ssl/ca1_server2.crt");
+	tls_keypair_set_cert_file(kp2a, "ssl/ca1_server1.crt");
+	tls_keypair_set_cert_file(kp2b, "ssl/different_ca1_server2.crt");
 
-  tt_assert(keypair_list_equal(kp1a, kp2a) == false);
+	tt_assert(keypair_list_equal(kp1a, kp2a) == false);
 end:;
 }
 

--- a/test/test_tls.c
+++ b/test/test_tls.c
@@ -594,7 +594,7 @@ end:
 #define COMPLEX1 "key=ssl/ca1_complex1.key", "cert=ssl/ca1_complex1.crt"
 #define COMPLEX2 "key=ssl/ca2_complex2.key", "cert=ssl/ca2_complex2.crt"
 
-static void test_tls_configs_equal(void *z)
+static void test_tls_config_equal(void *z)
 {
 	struct Worker *server = NULL;
 	struct Worker *server_unchanged = NULL;
@@ -604,8 +604,8 @@ static void test_tls_configs_equal(void *z)
 	str_check(create_worker(&server_unchanged, true, SERVER1, NULL), "OK");
 	str_check(create_worker(&server_changed, true, SERVER2, NULL), "OK");
 
-	tt_assert(tls_configs_equal(server->config, server_unchanged->config) == true);
-	tt_assert(tls_configs_equal(server->config, server_changed->config) == false);
+	tt_assert(tls_config_equal(server->config, server_unchanged->config) == true);
+	tt_assert(tls_config_equal(server->config, server_changed->config) == false);
 end:;
 }
 
@@ -1063,7 +1063,7 @@ struct testcase_t tls_tests[] = {
 	{ "set-mem", test_set_mem },
 	{ "cipher-nego", test_cipher_nego },
 	{ "cert-info", test_cert_info },
-	{ "tls_configs_equal", test_tls_configs_equal },
+	{ "tls_config_equal", test_tls_config_equal },
 	END_OF_TESTCASES,
 	{ "servername", test_servername },
 };

--- a/test/test_tls.c
+++ b/test/test_tls.c
@@ -629,6 +629,24 @@ static void test_tls_keypair_list_equal(void *z)
 end:;
 }
 
+static void test_tls_keypair_list_length(void *z)
+{
+	struct tls_keypair *kp1a, *kp1b, *kp2a;
+	kp1a = tls_keypair_new();
+	kp1b = tls_keypair_new();
+	kp2a = tls_keypair_new();
+
+  /* this keypair list is one keypair longer */
+	kp1a->next = kp1b;
+
+	tls_keypair_set_cert_file(kp1a, "ssl/ca1_server1.crt");
+	tls_keypair_set_cert_file(kp1b, "ssl/ca1_server2.crt");
+	tls_keypair_set_cert_file(kp2a, "ssl/ca1_server1.crt");
+
+	tt_assert(tls_keypair_list_equal(kp1a, kp2a) == false);
+end:;
+}
+
 static void test_verify(void *z)
 {
 	struct Worker *server = NULL, *client = NULL;
@@ -1085,6 +1103,7 @@ struct testcase_t tls_tests[] = {
 	{ "cert-info", test_cert_info },
 	{ "tls_config_equal", test_tls_config_equal },
 	{ "tls_keypair_list_equal", test_tls_keypair_list_equal },
+	{ "tls_keypair_list_length", test_tls_keypair_list_length },
 	END_OF_TESTCASES,
 	{ "servername", test_servername },
 };

--- a/usual/string.c
+++ b/usual/string.c
@@ -677,3 +677,17 @@ size_t strnlen(const char *string, size_t maxlen)
 }
 
 #endif
+
+/*
+ * Same as strcmp, but handles NULLs. If both sides are NULL, returns "true".
+ */
+bool strings_equal(const char *str_left, const char *str_right)
+{
+	if (str_left == NULL && str_right == NULL)
+		return true;
+
+	if (str_left == NULL || str_right == NULL)
+		return false;
+
+	return strcmp(str_left, str_right) == 0;
+}

--- a/usual/string.c
+++ b/usual/string.c
@@ -681,7 +681,7 @@ size_t strnlen(const char *string, size_t maxlen)
 /*
  * Same as strcmp, but handles NULLs. If both sides are NULL, returns "true".
  */
-bool strings_equal(const char *str_left, const char *str_right)
+bool strcmpeq(const char *str_left, const char *str_right)
 {
 	if (str_left == NULL && str_right == NULL)
 		return true;

--- a/usual/string.h
+++ b/usual/string.h
@@ -214,4 +214,6 @@ int asprintf(char **dst_p, const char *fmt, ...) _PRINTF(2, 3);
 int vasprintf(char **dst_p, const char *fmt, va_list ap) _PRINTF(2, 0);
 #endif
 
+bool strings_equal(const char *str_left, const char *str_right);
+
 #endif

--- a/usual/string.h
+++ b/usual/string.h
@@ -214,6 +214,6 @@ int asprintf(char **dst_p, const char *fmt, ...) _PRINTF(2, 3);
 int vasprintf(char **dst_p, const char *fmt, va_list ap) _PRINTF(2, 0);
 #endif
 
-bool strings_equal(const char *str_left, const char *str_right);
+bool strcmpeq(const char *str_left, const char *str_right);
 
 #endif

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -743,87 +743,87 @@ tls_close(struct tls *ctx)
 }
 
 static bool
-tls_mems_equal(char *left_cert_mem, char *right_cert_mem, size_t left_cert_len, size_t right_cert_len)
+tls_mems_equal(char *mem1, char *mem2, size_t len1, size_t len2)
 {
-  if (left_cert_mem != right_cert_mem)
+  if (mem1 != mem2)
     return false;
-  if (left_cert_mem && right_cert_mem && memcmp(left_cert_mem, right_cert_mem, left_cert_len) != 0)
+  if (mem1 && mem2 && memcmp(mem1, mem2, len1) != 0)
     return false;
   return true;
 }
 
 static bool
-tls_config_keypair_equal(struct tls_keypair *left_tls_keypair, struct tls_keypair *right_tls_keypair)
+tls_config_keypair_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 {
-  if (!strings_equal(left_tls_keypair->cert_file, right_tls_keypair->cert_file))
+  if (!strings_equal(tkp1->cert_file, tkp2->cert_file))
     return false;
-  if (!tls_mems_equal(left_tls_keypair->cert_mem, right_tls_keypair->cert_mem, left_tls_keypair->cert_len, right_tls_keypair->cert_len))
+  if (!tls_mems_equal(tkp1->cert_mem, tkp2->cert_mem, tkp1->cert_len, tkp2->cert_len))
     return false;
-  if (!strings_equal(left_tls_keypair->key_file, right_tls_keypair->key_file))
+  if (!strings_equal(tkp1->key_file, tkp2->key_file))
     return false;
-  if (!tls_mems_equal(left_tls_keypair->key_mem, right_tls_keypair->key_mem, left_tls_keypair->key_len, right_tls_keypair->key_len))
+  if (!tls_mems_equal(tkp1->key_mem, tkp2->key_mem, tkp1->key_len, tkp2->key_len))
     return false;
   return true;
 }
 
 static bool
-tls_config_keypairs_equal(struct tls_keypair *tls_keypair_left, struct tls_keypair *tls_keypair_right)
+tls_config_keypairs_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 {
-	bool keypair_unchanged;
+	bool kp_unchanged;
 	struct tls_keypair *tls_kp_lt, *next_tls_kp_lt, *tls_kp_rt, *next_tls_kp_rt;
 
-	keypair_unchanged = tls_config_keypair_equal(tls_keypair_left, tls_keypair_right);
+	kp_unchanged = tls_config_keypair_equal(tkp1, tkp2);
 
-	if (keypair_unchanged == false) {
+	if (kp_unchanged == false) {
 		return false;
 	}
 
-	for (tls_kp_lt = tls_keypair_left; tls_kp_lt != NULL; tls_kp_lt = next_tls_kp_lt) {
+	for (tls_kp_lt = tkp1; tls_kp_lt != NULL; tls_kp_lt = next_tls_kp_lt) {
 		next_tls_kp_lt = tls_kp_lt->next;
-		for (tls_kp_rt = tls_keypair_right; tls_kp_rt != NULL; tls_kp_rt = next_tls_kp_rt) {
+		for (tls_kp_rt = tkp2; tls_kp_rt != NULL; tls_kp_rt = next_tls_kp_rt) {
 			next_tls_kp_rt = tls_kp_rt->next;
 
-			keypair_unchanged = tls_config_keypair_equal(tls_kp_lt, tls_kp_rt);
+			kp_unchanged = tls_config_keypair_equal(tls_kp_lt, tls_kp_rt);
 		}
 	}
 
-	return keypair_unchanged;
+	return kp_unchanged;
 }
 
 bool
-tls_configs_equal(struct tls_config *tls_config_left, struct tls_config *tls_config_right)
+tls_configs_equal(struct tls_config *tc1, struct tls_config *tc2)
 {
-  if (!strings_equal(tls_config_left->ca_file, tls_config_right->ca_file))
+  if (!strings_equal(tc1->ca_file, tc2->ca_file))
     return false;
-  if (!strings_equal(tls_config_left->ca_path, tls_config_right->ca_path))
+  if (!strings_equal(tc1->ca_path, tc2->ca_path))
     return false;
-  if (!tls_mems_equal(tls_config_left->ca_mem, tls_config_right->ca_mem, tls_config_left->ca_len, tls_config_right->ca_len))
+  if (!tls_mems_equal(tc1->ca_mem, tc2->ca_mem, tc1->ca_len, tc2->ca_len))
     return false;
-  if (!strings_equal(tls_config_left->ciphers, tls_config_right->ciphers))
+  if (!strings_equal(tc1->ciphers, tc2->ciphers))
     return false;
-  if (tls_config_left->ciphers_server != tls_config_right->ciphers_server)
+  if (tc1->ciphers_server != tc2->ciphers_server)
     return false;
-  if (tls_config_left->dheparams != tls_config_right->dheparams)
+  if (tc1->dheparams != tc2->dheparams)
     return false;
-  if (tls_config_left->ecdhecurve != tls_config_right->ecdhecurve)
+  if (tc1->ecdhecurve != tc2->ecdhecurve)
     return false;
-  if (!(tls_config_keypairs_equal(tls_config_left->keypair, tls_config_right->keypair)))
+  if (!(tls_config_keypairs_equal(tc1->keypair, tc2->keypair)))
     return false;
-  if (!strings_equal(tls_config_left->ocsp_file, tls_config_right->ocsp_file))
+  if (!strings_equal(tc1->ocsp_file, tc2->ocsp_file))
     return false;
-  if (!tls_mems_equal(tls_config_left->ocsp_mem, tls_config_right->ocsp_mem, tls_config_left->ocsp_len, tls_config_right->ocsp_len))
+  if (!tls_mems_equal(tc1->ocsp_mem, tc2->ocsp_mem, tc1->ocsp_len, tc2->ocsp_len))
     return false;
-  if (tls_config_left->protocols != tls_config_right->protocols)
+  if (tc1->protocols != tc2->protocols)
     return false;
-  if (tls_config_left->verify_cert != tls_config_right->verify_cert)
+  if (tc1->verify_cert != tc2->verify_cert)
     return false;
-  if (tls_config_left->verify_client != tls_config_right->verify_client)
+  if (tc1->verify_client != tc2->verify_client)
     return false;
-  if (tls_config_left->verify_depth != tls_config_right->verify_depth)
+  if (tc1->verify_depth != tc2->verify_depth)
     return false;
-  if (tls_config_left->verify_name != tls_config_right->verify_name)
+  if (tc1->verify_name != tc2->verify_name)
     return false;
-  if (tls_config_left->verify_time != tls_config_right->verify_time)
+  if (tc1->verify_time != tc2->verify_time)
     return false;
   return true;
 }

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -755,11 +755,11 @@ tls_mems_equal(char *mem1, char *mem2, size_t len1, size_t len2)
 static bool
 keypair_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 {
-  if (!strings_equal(tkp1->cert_file, tkp2->cert_file))
+  if (!strcmpeq(tkp1->cert_file, tkp2->cert_file))
     return false;
   if (!tls_mems_equal(tkp1->cert_mem, tkp2->cert_mem, tkp1->cert_len, tkp2->cert_len))
     return false;
-  if (!strings_equal(tkp1->key_file, tkp2->key_file))
+  if (!strcmpeq(tkp1->key_file, tkp2->key_file))
     return false;
   if (!tls_mems_equal(tkp1->key_mem, tkp2->key_mem, tkp1->key_len, tkp2->key_len))
     return false;
@@ -793,13 +793,13 @@ keypairs_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 bool
 tls_config_equal(struct tls_config *tc1, struct tls_config *tc2)
 {
-  if (!strings_equal(tc1->ca_file, tc2->ca_file))
+  if (!strcmpeq(tc1->ca_file, tc2->ca_file))
     return false;
-  if (!strings_equal(tc1->ca_path, tc2->ca_path))
+  if (!strcmpeq(tc1->ca_path, tc2->ca_path))
     return false;
   if (!tls_mems_equal(tc1->ca_mem, tc2->ca_mem, tc1->ca_len, tc2->ca_len))
     return false;
-  if (!strings_equal(tc1->ciphers, tc2->ciphers))
+  if (!strcmpeq(tc1->ciphers, tc2->ciphers))
     return false;
   if (tc1->ciphers_server != tc2->ciphers_server)
     return false;
@@ -809,7 +809,7 @@ tls_config_equal(struct tls_config *tc1, struct tls_config *tc2)
     return false;
   if (!(keypairs_equal(tc1->keypair, tc2->keypair)))
     return false;
-  if (!strings_equal(tc1->ocsp_file, tc2->ocsp_file))
+  if (!strcmpeq(tc1->ocsp_file, tc2->ocsp_file))
     return false;
   if (!tls_mems_equal(tc1->ocsp_mem, tc2->ocsp_mem, tc1->ocsp_len, tc2->ocsp_len))
     return false;

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -745,10 +745,15 @@ tls_close(struct tls *ctx)
 static bool
 tls_config_keypair_equal(struct tls_keypair *left_tls_keypair, struct tls_keypair *right_tls_keypair)
 {
-	return (strings_equal(left_tls_keypair->cert_file, right_tls_keypair->cert_file) &&
-		memcmp(left_tls_keypair->cert_mem, right_tls_keypair->cert_mem, left_tls_keypair->cert_len) == 0 &&
-		strings_equal(left_tls_keypair->key_file, right_tls_keypair->key_file) &&
-		memcmp(left_tls_keypair->key_mem, right_tls_keypair->key_mem, left_tls_keypair->key_len) == 0);
+  if (!strings_equal(left_tls_keypair->cert_file, right_tls_keypair->cert_file))
+    return false;
+  if (!(memcmp(left_tls_keypair->cert_mem, right_tls_keypair->cert_mem, left_tls_keypair->cert_len) == 0))
+    return false;
+  if (!strings_equal(left_tls_keypair->key_file, right_tls_keypair->key_file))
+    return false;
+  if ((!memcmp(left_tls_keypair->key_mem, right_tls_keypair->key_mem, left_tls_keypair->key_len) == 0))
+    return false;
+  return true;
 }
 
 static bool
@@ -778,22 +783,39 @@ tls_config_keypairs_equal(struct tls_keypair *tls_keypair_left, struct tls_keypa
 bool
 tls_configs_equal(struct tls_config *tls_config_left, struct tls_config *tls_config_right)
 {
-	return (strings_equal(tls_config_left->ca_file, tls_config_right->ca_file) &&
-		strings_equal(tls_config_left->ca_path, tls_config_right->ca_path) &&
-		memcmp(tls_config_left->ca_mem, tls_config_right->ca_mem, tls_config_left->ca_len) == 0 &&
-		strings_equal(tls_config_left->ciphers, tls_config_right->ciphers) &&
-		(tls_config_left->ciphers_server == tls_config_right->ciphers_server) &&
-		(tls_config_left->dheparams == tls_config_right->dheparams) &&
-		(tls_config_left->ecdhecurve == tls_config_right->ecdhecurve) &&
-		tls_config_keypairs_equal(tls_config_left->keypair, tls_config_right->keypair) &&
-		strings_equal(tls_config_left->ocsp_file, tls_config_right->ocsp_file) &&
-		memcmp(tls_config_left->ocsp_mem, tls_config_right->ocsp_mem, tls_config_left->ocsp_len) == 0 &&
-		(tls_config_left->protocols == tls_config_right->protocols) &&
-		(tls_config_left->verify_cert == tls_config_right->verify_cert) &&
-		(tls_config_left->verify_client == tls_config_right->verify_client) &&
-		(tls_config_left->verify_depth == tls_config_right->verify_depth) &&
-		(tls_config_left->verify_name == tls_config_right->verify_name) &&
-		(tls_config_left->verify_time == tls_config_right->verify_time));
+  if (!(strings_equal(tls_config_left->ca_file, tls_config_right->ca_file)))
+    return false;
+  if (!(strings_equal(tls_config_left->ca_path, tls_config_right->ca_path)))
+    return false;
+  if (!(memcmp(tls_config_left->ca_mem, tls_config_right->ca_mem, tls_config_left->ca_len) == 0))
+    return false;
+  if (!(strings_equal(tls_config_left->ciphers, tls_config_right->ciphers)))
+    return false;
+  if (!(tls_config_left->ciphers_server == tls_config_right->ciphers_server))
+    return false;
+  if (!(tls_config_left->dheparams == tls_config_right->dheparams))
+    return false;
+  if (!(tls_config_left->ecdhecurve == tls_config_right->ecdhecurve))
+    return false;
+  if (!(tls_config_keypairs_equal(tls_config_left->keypair, tls_config_right->keypair)))
+    return false;
+  if (!(strings_equal(tls_config_left->ocsp_file, tls_config_right->ocsp_file)))
+    return false;
+  if (!(memcmp(tls_config_left->ocsp_mem, tls_config_right->ocsp_mem, tls_config_left->ocsp_len) == 0))
+    return false;
+  if (!(tls_config_left->protocols == tls_config_right->protocols))
+    return false;
+  if (!(tls_config_left->verify_cert == tls_config_right->verify_cert))
+    return false;
+  if (!(tls_config_left->verify_client == tls_config_right->verify_client))
+    return false;
+  if (!(tls_config_left->verify_depth == tls_config_right->verify_depth))
+    return false;
+  if (!(tls_config_left->verify_name == tls_config_right->verify_name))
+    return false;
+  if (!(tls_config_left->verify_time == tls_config_right->verify_time))
+    return false;
+  return true;
 }
 
 #endif /* USUAL_LIBSSL_FOR_TLS */

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -742,4 +742,58 @@ tls_close(struct tls *ctx)
 	return (rv);
 }
 
+static bool
+tls_config_keypair_equal(struct tls_keypair *left_tls_keypair, struct tls_keypair *right_tls_keypair)
+{
+	return (strings_equal(left_tls_keypair->cert_file, right_tls_keypair->cert_file) &&
+		memcmp(left_tls_keypair->cert_mem, right_tls_keypair->cert_mem, left_tls_keypair->cert_len) == 0 &&
+		strings_equal(left_tls_keypair->key_file, right_tls_keypair->key_file) &&
+		memcmp(left_tls_keypair->key_mem, right_tls_keypair->key_mem, left_tls_keypair->key_len) == 0);
+}
+
+static bool
+tls_config_keypairs_equal(struct tls_keypair *tls_keypair_left, struct tls_keypair *tls_keypair_right)
+{
+	bool keypair_unchanged;
+	struct tls_keypair *tls_kp_lt, *next_tls_kp_lt, *tls_kp_rt, *next_tls_kp_rt;
+
+	keypair_unchanged = tls_config_keypair_equal(tls_keypair_left, tls_keypair_right);
+
+	if (keypair_unchanged == false) {
+		return false;
+	}
+
+	for (tls_kp_lt = tls_keypair_left; tls_kp_lt != NULL; tls_kp_lt = next_tls_kp_lt) {
+		next_tls_kp_lt = tls_kp_lt->next;
+		for (tls_kp_rt = tls_keypair_right; tls_kp_rt != NULL; tls_kp_rt = next_tls_kp_rt) {
+			next_tls_kp_rt = tls_kp_rt->next;
+
+			keypair_unchanged = tls_config_keypair_equal(tls_kp_lt, tls_kp_rt);
+		}
+	}
+
+	return keypair_unchanged;
+}
+
+bool
+tls_configs_equal(struct tls_config *tls_config_left, struct tls_config *tls_config_right)
+{
+	return (strings_equal(tls_config_left->ca_file, tls_config_right->ca_file) &&
+		strings_equal(tls_config_left->ca_path, tls_config_right->ca_path) &&
+		memcmp(tls_config_left->ca_mem, tls_config_right->ca_mem, tls_config_left->ca_len) == 0 &&
+		strings_equal(tls_config_left->ciphers, tls_config_right->ciphers) &&
+		(tls_config_left->ciphers_server == tls_config_right->ciphers_server) &&
+		(tls_config_left->dheparams == tls_config_right->dheparams) &&
+		(tls_config_left->ecdhecurve == tls_config_right->ecdhecurve) &&
+		tls_config_keypairs_equal(tls_config_left->keypair, tls_config_right->keypair) &&
+		strings_equal(tls_config_left->ocsp_file, tls_config_right->ocsp_file) &&
+		memcmp(tls_config_left->ocsp_mem, tls_config_right->ocsp_mem, tls_config_left->ocsp_len) == 0 &&
+		(tls_config_left->protocols == tls_config_right->protocols) &&
+		(tls_config_left->verify_cert == tls_config_right->verify_cert) &&
+		(tls_config_left->verify_client == tls_config_right->verify_client) &&
+		(tls_config_left->verify_depth == tls_config_right->verify_depth) &&
+		(tls_config_left->verify_name == tls_config_right->verify_name) &&
+		(tls_config_left->verify_time == tls_config_right->verify_time));
+}
+
 #endif /* USUAL_LIBSSL_FOR_TLS */

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -767,7 +767,7 @@ keypair_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 }
 
 static bool
-keypairs_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
+keypair_list_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 {
 	bool kp_unchanged;
 	struct tls_keypair *tls_kp_lt, *next_tls_kp_lt, *tls_kp_rt, *next_tls_kp_rt;
@@ -807,7 +807,7 @@ tls_config_equal(struct tls_config *tc1, struct tls_config *tc2)
     return false;
   if (tc1->ecdhecurve != tc2->ecdhecurve)
     return false;
-  if (!(keypairs_equal(tc1->keypair, tc2->keypair)))
+  if (!(keypair_list_equal(tc1->keypair, tc2->keypair)))
     return false;
   if (!strcmpeq(tc1->ocsp_file, tc2->ocsp_file))
     return false;

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -745,12 +745,12 @@ tls_close(struct tls *ctx)
 static bool
 tls_config_keypair_equal(struct tls_keypair *left_tls_keypair, struct tls_keypair *right_tls_keypair)
 {
-  if !strings_equal(left_tls_keypair->cert_file, right_tls_keypair->cert_file)
+  if (!strings_equal(left_tls_keypair->cert_file, right_tls_keypair->cert_file))
     return false;
   if (left_tls_keypair->cert_mem && right_tls_keypair->cert_mem &&
       !(memcmp(left_tls_keypair->cert_mem, right_tls_keypair->cert_mem, left_tls_keypair->cert_len) == 0))
     return false;
-  if !strings_equal(left_tls_keypair->key_file, right_tls_keypair->key_file)
+  if (!strings_equal(left_tls_keypair->key_file, right_tls_keypair->key_file))
     return false;
   if (left_tls_keypair->key_mem && right_tls_keypair->key_mem &&
       !(memcmp(left_tls_keypair->key_mem, right_tls_keypair->key_mem, left_tls_keypair->key_len) != 0))
@@ -785,14 +785,14 @@ tls_config_keypairs_equal(struct tls_keypair *tls_keypair_left, struct tls_keypa
 bool
 tls_configs_equal(struct tls_config *tls_config_left, struct tls_config *tls_config_right)
 {
-  if !(strings_equal(tls_config_left->ca_file, tls_config_right->ca_file))
+  if (!strings_equal(tls_config_left->ca_file, tls_config_right->ca_file))
     return false;
-  if !(strings_equal(tls_config_left->ca_path, tls_config_right->ca_path))
+  if (!strings_equal(tls_config_left->ca_path, tls_config_right->ca_path))
     return false;
   if (tls_config_left->ca_mem &&  tls_config_right->ca_mem &&
       !(memcmp(tls_config_left->ca_mem, tls_config_right->ca_mem, tls_config_left->ca_len) == 0))
     return false;
-  if !(strings_equal(tls_config_left->ciphers, tls_config_right->ciphers))
+  if (!strings_equal(tls_config_left->ciphers, tls_config_right->ciphers))
     return false;
   if (tls_config_left->ciphers_server != tls_config_right->ciphers_server)
     return false;
@@ -802,7 +802,7 @@ tls_configs_equal(struct tls_config *tls_config_left, struct tls_config *tls_con
     return false;
   if (!(tls_config_keypairs_equal(tls_config_left->keypair, tls_config_right->keypair)))
     return false;
-  if !(strings_equal(tls_config_left->ocsp_file, tls_config_right->ocsp_file))
+  if (!strings_equal(tls_config_left->ocsp_file, tls_config_right->ocsp_file))
     return false;
   if (tls_config_left->ocsp_mem && tls_config_right->ocsp_mem &&
       !(memcmp(tls_config_left->ocsp_mem, tls_config_right->ocsp_mem, tls_config_left->ocsp_len) == 0))

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -769,20 +769,12 @@ tls_keypair_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 bool
 tls_keypair_list_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 {
-	bool kp_unchanged;
-	struct tls_keypair *tls_kp_lt, *tls_kp_rt;
-
-	kp_unchanged = tls_keypair_equal(tkp1, tkp2);
-
-	if (kp_unchanged == false) {
-		return false;
+	for (; tkp1 != NULL && tkp2 != NULL; tkp1 = tkp1->next, tkp2 = tkp2->next) {
+		if (!tls_keypair_equal(tkp1, tkp2))
+			return false;
 	}
 
-	for (tls_kp_lt = tkp1, tls_kp_rt = tkp2 ; tls_kp_lt != NULL && tls_kp_rt != NULL; tls_kp_lt = tls_kp_lt->next, tls_kp_rt = tls_kp_rt->next) {
-		kp_unchanged = tls_keypair_equal(tls_kp_lt, tls_kp_rt);
-	}
-
-	return kp_unchanged;
+	return tkp1 == NULL && tkp2 == NULL;
 }
 
 bool

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -743,17 +743,23 @@ tls_close(struct tls *ctx)
 }
 
 static bool
+tls_mems_equal(char *left_cert_mem, char *right_cert_mem, size_t cert_len)
+{
+  if (left_cert_mem && right_cert_mem && memcmp(left_cert_mem, right_cert_mem, cert_len) != 0)
+    return false;
+  return true;
+}
+
+static bool
 tls_config_keypair_equal(struct tls_keypair *left_tls_keypair, struct tls_keypair *right_tls_keypair)
 {
   if (!strings_equal(left_tls_keypair->cert_file, right_tls_keypair->cert_file))
     return false;
-  if (left_tls_keypair->cert_mem && right_tls_keypair->cert_mem &&
-      !(memcmp(left_tls_keypair->cert_mem, right_tls_keypair->cert_mem, left_tls_keypair->cert_len) == 0))
+  if (!tls_mems_equal(left_tls_keypair->cert_mem, right_tls_keypair->cert_mem, left_tls_keypair->cert_len))
     return false;
   if (!strings_equal(left_tls_keypair->key_file, right_tls_keypair->key_file))
     return false;
-  if (left_tls_keypair->key_mem && right_tls_keypair->key_mem &&
-      !(memcmp(left_tls_keypair->key_mem, right_tls_keypair->key_mem, left_tls_keypair->key_len) != 0))
+  if (!tls_mems_equal(left_tls_keypair->key_mem, right_tls_keypair->key_mem, left_tls_keypair->key_len))
     return false;
   return true;
 }
@@ -789,8 +795,7 @@ tls_configs_equal(struct tls_config *tls_config_left, struct tls_config *tls_con
     return false;
   if (!strings_equal(tls_config_left->ca_path, tls_config_right->ca_path))
     return false;
-  if (tls_config_left->ca_mem &&  tls_config_right->ca_mem &&
-      !(memcmp(tls_config_left->ca_mem, tls_config_right->ca_mem, tls_config_left->ca_len) == 0))
+  if (!tls_mems_equal(tls_config_left->ca_mem, tls_config_right->ca_mem, tls_config_left->ca_len))
     return false;
   if (!strings_equal(tls_config_left->ciphers, tls_config_right->ciphers))
     return false;
@@ -804,8 +809,7 @@ tls_configs_equal(struct tls_config *tls_config_left, struct tls_config *tls_con
     return false;
   if (!strings_equal(tls_config_left->ocsp_file, tls_config_right->ocsp_file))
     return false;
-  if (tls_config_left->ocsp_mem && tls_config_right->ocsp_mem &&
-      !(memcmp(tls_config_left->ocsp_mem, tls_config_right->ocsp_mem, tls_config_left->ocsp_len) == 0))
+  if (!tls_mems_equal(tls_config_left->ocsp_mem, tls_config_right->ocsp_mem, tls_config_left->ocsp_len))
     return false;
   if (tls_config_left->protocols != tls_config_right->protocols)
     return false;

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -745,12 +745,12 @@ tls_close(struct tls *ctx)
 static bool
 tls_config_keypair_equal(struct tls_keypair *left_tls_keypair, struct tls_keypair *right_tls_keypair)
 {
-  if (!strings_equal(left_tls_keypair->cert_file, right_tls_keypair->cert_file))
+  if !strings_equal(left_tls_keypair->cert_file, right_tls_keypair->cert_file)
     return false;
   if (left_tls_keypair->cert_mem && right_tls_keypair->cert_mem &&
       !(memcmp(left_tls_keypair->cert_mem, right_tls_keypair->cert_mem, left_tls_keypair->cert_len) == 0))
     return false;
-  if (!strings_equal(left_tls_keypair->key_file, right_tls_keypair->key_file))
+  if !strings_equal(left_tls_keypair->key_file, right_tls_keypair->key_file)
     return false;
   if (left_tls_keypair->key_mem && right_tls_keypair->key_mem &&
       !(memcmp(left_tls_keypair->key_mem, right_tls_keypair->key_mem, left_tls_keypair->key_len) != 0))
@@ -785,39 +785,39 @@ tls_config_keypairs_equal(struct tls_keypair *tls_keypair_left, struct tls_keypa
 bool
 tls_configs_equal(struct tls_config *tls_config_left, struct tls_config *tls_config_right)
 {
-  if (!(strings_equal(tls_config_left->ca_file, tls_config_right->ca_file)))
+  if !(strings_equal(tls_config_left->ca_file, tls_config_right->ca_file))
     return false;
-  if (!(strings_equal(tls_config_left->ca_path, tls_config_right->ca_path)))
+  if !(strings_equal(tls_config_left->ca_path, tls_config_right->ca_path))
     return false;
   if (tls_config_left->ca_mem &&  tls_config_right->ca_mem &&
       !(memcmp(tls_config_left->ca_mem, tls_config_right->ca_mem, tls_config_left->ca_len) == 0))
     return false;
-  if (!(strings_equal(tls_config_left->ciphers, tls_config_right->ciphers)))
+  if !(strings_equal(tls_config_left->ciphers, tls_config_right->ciphers))
     return false;
-  if (!(tls_config_left->ciphers_server == tls_config_right->ciphers_server))
+  if (tls_config_left->ciphers_server != tls_config_right->ciphers_server)
     return false;
-  if (!(tls_config_left->dheparams == tls_config_right->dheparams))
+  if (tls_config_left->dheparams != tls_config_right->dheparams)
     return false;
-  if (!(tls_config_left->ecdhecurve == tls_config_right->ecdhecurve))
+  if (tls_config_left->ecdhecurve != tls_config_right->ecdhecurve)
     return false;
   if (!(tls_config_keypairs_equal(tls_config_left->keypair, tls_config_right->keypair)))
     return false;
-  if (!(strings_equal(tls_config_left->ocsp_file, tls_config_right->ocsp_file)))
+  if !(strings_equal(tls_config_left->ocsp_file, tls_config_right->ocsp_file))
     return false;
   if (tls_config_left->ocsp_mem && tls_config_right->ocsp_mem &&
       !(memcmp(tls_config_left->ocsp_mem, tls_config_right->ocsp_mem, tls_config_left->ocsp_len) == 0))
     return false;
-  if (!(tls_config_left->protocols == tls_config_right->protocols))
+  if (tls_config_left->protocols != tls_config_right->protocols)
     return false;
-  if (!(tls_config_left->verify_cert == tls_config_right->verify_cert))
+  if (tls_config_left->verify_cert != tls_config_right->verify_cert)
     return false;
-  if (!(tls_config_left->verify_client == tls_config_right->verify_client))
+  if (tls_config_left->verify_client != tls_config_right->verify_client)
     return false;
-  if (!(tls_config_left->verify_depth == tls_config_right->verify_depth))
+  if (tls_config_left->verify_depth != tls_config_right->verify_depth)
     return false;
-  if (!(tls_config_left->verify_name == tls_config_right->verify_name))
+  if (tls_config_left->verify_name != tls_config_right->verify_name)
     return false;
-  if (!(tls_config_left->verify_time == tls_config_right->verify_time))
+  if (tls_config_left->verify_time != tls_config_right->verify_time)
     return false;
   return true;
 }

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -745,7 +745,7 @@ tls_close(struct tls *ctx)
 static bool
 tls_mems_equal(char *mem1, char *mem2, size_t len1, size_t len2)
 {
-  if (mem1 != mem2)
+  if (len1 != len2)
     return false;
   if (mem1 && mem2 && memcmp(mem1, mem2, len1) != 0)
     return false;

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -747,11 +747,13 @@ tls_config_keypair_equal(struct tls_keypair *left_tls_keypair, struct tls_keypai
 {
   if (!strings_equal(left_tls_keypair->cert_file, right_tls_keypair->cert_file))
     return false;
-  if (!(memcmp(left_tls_keypair->cert_mem, right_tls_keypair->cert_mem, left_tls_keypair->cert_len) == 0))
+  if (left_tls_keypair->cert_mem && right_tls_keypair->cert_mem &&
+      !(memcmp(left_tls_keypair->cert_mem, right_tls_keypair->cert_mem, left_tls_keypair->cert_len) == 0))
     return false;
   if (!strings_equal(left_tls_keypair->key_file, right_tls_keypair->key_file))
     return false;
-  if ((!memcmp(left_tls_keypair->key_mem, right_tls_keypair->key_mem, left_tls_keypair->key_len) == 0))
+  if (left_tls_keypair->key_mem && right_tls_keypair->key_mem &&
+      !(memcmp(left_tls_keypair->key_mem, right_tls_keypair->key_mem, left_tls_keypair->key_len) != 0))
     return false;
   return true;
 }
@@ -787,7 +789,8 @@ tls_configs_equal(struct tls_config *tls_config_left, struct tls_config *tls_con
     return false;
   if (!(strings_equal(tls_config_left->ca_path, tls_config_right->ca_path)))
     return false;
-  if (!(memcmp(tls_config_left->ca_mem, tls_config_right->ca_mem, tls_config_left->ca_len) == 0))
+  if (tls_config_left->ca_mem &&  tls_config_right->ca_mem &&
+      !(memcmp(tls_config_left->ca_mem, tls_config_right->ca_mem, tls_config_left->ca_len) == 0))
     return false;
   if (!(strings_equal(tls_config_left->ciphers, tls_config_right->ciphers)))
     return false;
@@ -801,7 +804,8 @@ tls_configs_equal(struct tls_config *tls_config_left, struct tls_config *tls_con
     return false;
   if (!(strings_equal(tls_config_left->ocsp_file, tls_config_right->ocsp_file)))
     return false;
-  if (!(memcmp(tls_config_left->ocsp_mem, tls_config_right->ocsp_mem, tls_config_left->ocsp_len) == 0))
+  if (tls_config_left->ocsp_mem && tls_config_right->ocsp_mem &&
+      !(memcmp(tls_config_left->ocsp_mem, tls_config_right->ocsp_mem, tls_config_left->ocsp_len) == 0))
     return false;
   if (!(tls_config_left->protocols == tls_config_right->protocols))
     return false;

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -753,7 +753,7 @@ tls_mems_equal(char *mem1, char *mem2, size_t len1, size_t len2)
 }
 
 static bool
-tls_config_keypair_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
+keypair_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 {
   if (!strings_equal(tkp1->cert_file, tkp2->cert_file))
     return false;
@@ -767,12 +767,12 @@ tls_config_keypair_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 }
 
 static bool
-tls_config_keypairs_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
+keypairs_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 {
 	bool kp_unchanged;
 	struct tls_keypair *tls_kp_lt, *next_tls_kp_lt, *tls_kp_rt, *next_tls_kp_rt;
 
-	kp_unchanged = tls_config_keypair_equal(tkp1, tkp2);
+	kp_unchanged = keypair_equal(tkp1, tkp2);
 
 	if (kp_unchanged == false) {
 		return false;
@@ -783,7 +783,7 @@ tls_config_keypairs_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 		for (tls_kp_rt = tkp2; tls_kp_rt != NULL; tls_kp_rt = next_tls_kp_rt) {
 			next_tls_kp_rt = tls_kp_rt->next;
 
-			kp_unchanged = tls_config_keypair_equal(tls_kp_lt, tls_kp_rt);
+			kp_unchanged = keypair_equal(tls_kp_lt, tls_kp_rt);
 		}
 	}
 
@@ -791,7 +791,7 @@ tls_config_keypairs_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 }
 
 bool
-tls_configs_equal(struct tls_config *tc1, struct tls_config *tc2)
+tls_config_equal(struct tls_config *tc1, struct tls_config *tc2)
 {
   if (!strings_equal(tc1->ca_file, tc2->ca_file))
     return false;
@@ -807,7 +807,7 @@ tls_configs_equal(struct tls_config *tc1, struct tls_config *tc2)
     return false;
   if (tc1->ecdhecurve != tc2->ecdhecurve)
     return false;
-  if (!(tls_config_keypairs_equal(tc1->keypair, tc2->keypair)))
+  if (!(keypairs_equal(tc1->keypair, tc2->keypair)))
     return false;
   if (!strings_equal(tc1->ocsp_file, tc2->ocsp_file))
     return false;

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -766,11 +766,11 @@ keypair_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
   return true;
 }
 
-static bool
+bool
 keypair_list_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 {
 	bool kp_unchanged;
-	struct tls_keypair *tls_kp_lt, *next_tls_kp_lt, *tls_kp_rt, *next_tls_kp_rt;
+	struct tls_keypair *tls_kp_lt, *tls_kp_rt;
 
 	kp_unchanged = keypair_equal(tkp1, tkp2);
 
@@ -778,13 +778,8 @@ keypair_list_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 		return false;
 	}
 
-	for (tls_kp_lt = tkp1; tls_kp_lt != NULL; tls_kp_lt = next_tls_kp_lt) {
-		next_tls_kp_lt = tls_kp_lt->next;
-		for (tls_kp_rt = tkp2; tls_kp_rt != NULL; tls_kp_rt = next_tls_kp_rt) {
-			next_tls_kp_rt = tls_kp_rt->next;
-
-			kp_unchanged = keypair_equal(tls_kp_lt, tls_kp_rt);
-		}
+  for (tls_kp_lt = tkp1, tls_kp_rt = tkp2 ; tls_kp_lt != NULL && tls_kp_rt != NULL; tls_kp_lt = tls_kp_lt->next, tls_kp_rt = tls_kp_rt->next) {
+    kp_unchanged = keypair_equal(tls_kp_lt, tls_kp_rt);
 	}
 
 	return kp_unchanged;

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -743,7 +743,7 @@ tls_close(struct tls *ctx)
 }
 
 static bool
-tls_mems_equal(char *mem1, char *mem2, size_t len1, size_t len2)
+tls_mem_equal(char *mem1, char *mem2, size_t len1, size_t len2)
 {
 	if (len1 != len2)
 		return false;
@@ -757,11 +757,11 @@ tls_keypair_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 {
 	if (!strcmpeq(tkp1->cert_file, tkp2->cert_file))
 		return false;
-	if (!tls_mems_equal(tkp1->cert_mem, tkp2->cert_mem, tkp1->cert_len, tkp2->cert_len))
+	if (!tls_mem_equal(tkp1->cert_mem, tkp2->cert_mem, tkp1->cert_len, tkp2->cert_len))
 		return false;
 	if (!strcmpeq(tkp1->key_file, tkp2->key_file))
 		return false;
-	if (!tls_mems_equal(tkp1->key_mem, tkp2->key_mem, tkp1->key_len, tkp2->key_len))
+	if (!tls_mem_equal(tkp1->key_mem, tkp2->key_mem, tkp1->key_len, tkp2->key_len))
 		return false;
 	return true;
 }
@@ -784,7 +784,7 @@ tls_config_equal(struct tls_config *tc1, struct tls_config *tc2)
 		return false;
 	if (!strcmpeq(tc1->ca_path, tc2->ca_path))
 		return false;
-	if (!tls_mems_equal(tc1->ca_mem, tc2->ca_mem, tc1->ca_len, tc2->ca_len))
+	if (!tls_mem_equal(tc1->ca_mem, tc2->ca_mem, tc1->ca_len, tc2->ca_len))
 		return false;
 	if (!strcmpeq(tc1->ciphers, tc2->ciphers))
 		return false;
@@ -794,11 +794,11 @@ tls_config_equal(struct tls_config *tc1, struct tls_config *tc2)
 		return false;
 	if (tc1->ecdhecurve != tc2->ecdhecurve)
 		return false;
-	if (!(tls_keypair_list_equal(tc1->keypair, tc2->keypair)))
+	if (!tls_keypair_list_equal(tc1->keypair, tc2->keypair))
 		return false;
 	if (!strcmpeq(tc1->ocsp_file, tc2->ocsp_file))
 		return false;
-	if (!tls_mems_equal(tc1->ocsp_mem, tc2->ocsp_mem, tc1->ocsp_len, tc2->ocsp_len))
+	if (!tls_mem_equal(tc1->ocsp_mem, tc2->ocsp_mem, tc1->ocsp_len, tc2->ocsp_len))
 		return false;
 	if (tc1->protocols != tc2->protocols)
 		return false;

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -745,25 +745,25 @@ tls_close(struct tls *ctx)
 static bool
 tls_mems_equal(char *mem1, char *mem2, size_t len1, size_t len2)
 {
-  if (len1 != len2)
-    return false;
-  if (mem1 && mem2 && memcmp(mem1, mem2, len1) != 0)
-    return false;
-  return true;
+	if (len1 != len2)
+		return false;
+	if (mem1 && mem2 && memcmp(mem1, mem2, len1) != 0)
+		return false;
+	return true;
 }
 
 static bool
 keypair_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 {
-  if (!strcmpeq(tkp1->cert_file, tkp2->cert_file))
-    return false;
-  if (!tls_mems_equal(tkp1->cert_mem, tkp2->cert_mem, tkp1->cert_len, tkp2->cert_len))
-    return false;
-  if (!strcmpeq(tkp1->key_file, tkp2->key_file))
-    return false;
-  if (!tls_mems_equal(tkp1->key_mem, tkp2->key_mem, tkp1->key_len, tkp2->key_len))
-    return false;
-  return true;
+	if (!strcmpeq(tkp1->cert_file, tkp2->cert_file))
+		return false;
+	if (!tls_mems_equal(tkp1->cert_mem, tkp2->cert_mem, tkp1->cert_len, tkp2->cert_len))
+		return false;
+	if (!strcmpeq(tkp1->key_file, tkp2->key_file))
+		return false;
+	if (!tls_mems_equal(tkp1->key_mem, tkp2->key_mem, tkp1->key_len, tkp2->key_len))
+		return false;
+	return true;
 }
 
 bool
@@ -778,8 +778,8 @@ keypair_list_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 		return false;
 	}
 
-  for (tls_kp_lt = tkp1, tls_kp_rt = tkp2 ; tls_kp_lt != NULL && tls_kp_rt != NULL; tls_kp_lt = tls_kp_lt->next, tls_kp_rt = tls_kp_rt->next) {
-    kp_unchanged = keypair_equal(tls_kp_lt, tls_kp_rt);
+	for (tls_kp_lt = tkp1, tls_kp_rt = tkp2 ; tls_kp_lt != NULL && tls_kp_rt != NULL; tls_kp_lt = tls_kp_lt->next, tls_kp_rt = tls_kp_rt->next) {
+		kp_unchanged = keypair_equal(tls_kp_lt, tls_kp_rt);
 	}
 
 	return kp_unchanged;
@@ -788,39 +788,39 @@ keypair_list_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 bool
 tls_config_equal(struct tls_config *tc1, struct tls_config *tc2)
 {
-  if (!strcmpeq(tc1->ca_file, tc2->ca_file))
-    return false;
-  if (!strcmpeq(tc1->ca_path, tc2->ca_path))
-    return false;
-  if (!tls_mems_equal(tc1->ca_mem, tc2->ca_mem, tc1->ca_len, tc2->ca_len))
-    return false;
-  if (!strcmpeq(tc1->ciphers, tc2->ciphers))
-    return false;
-  if (tc1->ciphers_server != tc2->ciphers_server)
-    return false;
-  if (tc1->dheparams != tc2->dheparams)
-    return false;
-  if (tc1->ecdhecurve != tc2->ecdhecurve)
-    return false;
-  if (!(keypair_list_equal(tc1->keypair, tc2->keypair)))
-    return false;
-  if (!strcmpeq(tc1->ocsp_file, tc2->ocsp_file))
-    return false;
-  if (!tls_mems_equal(tc1->ocsp_mem, tc2->ocsp_mem, tc1->ocsp_len, tc2->ocsp_len))
-    return false;
-  if (tc1->protocols != tc2->protocols)
-    return false;
-  if (tc1->verify_cert != tc2->verify_cert)
-    return false;
-  if (tc1->verify_client != tc2->verify_client)
-    return false;
-  if (tc1->verify_depth != tc2->verify_depth)
-    return false;
-  if (tc1->verify_name != tc2->verify_name)
-    return false;
-  if (tc1->verify_time != tc2->verify_time)
-    return false;
-  return true;
+	if (!strcmpeq(tc1->ca_file, tc2->ca_file))
+		return false;
+	if (!strcmpeq(tc1->ca_path, tc2->ca_path))
+		return false;
+	if (!tls_mems_equal(tc1->ca_mem, tc2->ca_mem, tc1->ca_len, tc2->ca_len))
+		return false;
+	if (!strcmpeq(tc1->ciphers, tc2->ciphers))
+		return false;
+	if (tc1->ciphers_server != tc2->ciphers_server)
+		return false;
+	if (tc1->dheparams != tc2->dheparams)
+		return false;
+	if (tc1->ecdhecurve != tc2->ecdhecurve)
+		return false;
+	if (!(keypair_list_equal(tc1->keypair, tc2->keypair)))
+		return false;
+	if (!strcmpeq(tc1->ocsp_file, tc2->ocsp_file))
+		return false;
+	if (!tls_mems_equal(tc1->ocsp_mem, tc2->ocsp_mem, tc1->ocsp_len, tc2->ocsp_len))
+		return false;
+	if (tc1->protocols != tc2->protocols)
+		return false;
+	if (tc1->verify_cert != tc2->verify_cert)
+		return false;
+	if (tc1->verify_client != tc2->verify_client)
+		return false;
+	if (tc1->verify_depth != tc2->verify_depth)
+		return false;
+	if (tc1->verify_name != tc2->verify_name)
+		return false;
+	if (tc1->verify_time != tc2->verify_time)
+		return false;
+	return true;
 }
 
 #endif /* USUAL_LIBSSL_FOR_TLS */

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -753,7 +753,7 @@ tls_mems_equal(char *mem1, char *mem2, size_t len1, size_t len2)
 }
 
 static bool
-keypair_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
+tls_keypair_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 {
 	if (!strcmpeq(tkp1->cert_file, tkp2->cert_file))
 		return false;
@@ -767,19 +767,19 @@ keypair_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 }
 
 bool
-keypair_list_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
+tls_keypair_list_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2)
 {
 	bool kp_unchanged;
 	struct tls_keypair *tls_kp_lt, *tls_kp_rt;
 
-	kp_unchanged = keypair_equal(tkp1, tkp2);
+	kp_unchanged = tls_keypair_equal(tkp1, tkp2);
 
 	if (kp_unchanged == false) {
 		return false;
 	}
 
 	for (tls_kp_lt = tkp1, tls_kp_rt = tkp2 ; tls_kp_lt != NULL && tls_kp_rt != NULL; tls_kp_lt = tls_kp_lt->next, tls_kp_rt = tls_kp_rt->next) {
-		kp_unchanged = keypair_equal(tls_kp_lt, tls_kp_rt);
+		kp_unchanged = tls_keypair_equal(tls_kp_lt, tls_kp_rt);
 	}
 
 	return kp_unchanged;
@@ -802,7 +802,7 @@ tls_config_equal(struct tls_config *tc1, struct tls_config *tc2)
 		return false;
 	if (tc1->ecdhecurve != tc2->ecdhecurve)
 		return false;
-	if (!(keypair_list_equal(tc1->keypair, tc2->keypair)))
+	if (!(tls_keypair_list_equal(tc1->keypair, tc2->keypair)))
 		return false;
 	if (!strcmpeq(tc1->ocsp_file, tc2->ocsp_file))
 		return false;

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -743,9 +743,11 @@ tls_close(struct tls *ctx)
 }
 
 static bool
-tls_mems_equal(char *left_cert_mem, char *right_cert_mem, size_t cert_len)
+tls_mems_equal(char *left_cert_mem, char *right_cert_mem, size_t left_cert_len, size_t right_cert_len)
 {
-  if (left_cert_mem && right_cert_mem && memcmp(left_cert_mem, right_cert_mem, cert_len) != 0)
+  if (left_cert_mem != right_cert_mem)
+    return false;
+  if (left_cert_mem && right_cert_mem && memcmp(left_cert_mem, right_cert_mem, left_cert_len) != 0)
     return false;
   return true;
 }
@@ -755,11 +757,11 @@ tls_config_keypair_equal(struct tls_keypair *left_tls_keypair, struct tls_keypai
 {
   if (!strings_equal(left_tls_keypair->cert_file, right_tls_keypair->cert_file))
     return false;
-  if (!tls_mems_equal(left_tls_keypair->cert_mem, right_tls_keypair->cert_mem, left_tls_keypair->cert_len))
+  if (!tls_mems_equal(left_tls_keypair->cert_mem, right_tls_keypair->cert_mem, left_tls_keypair->cert_len, right_tls_keypair->cert_len))
     return false;
   if (!strings_equal(left_tls_keypair->key_file, right_tls_keypair->key_file))
     return false;
-  if (!tls_mems_equal(left_tls_keypair->key_mem, right_tls_keypair->key_mem, left_tls_keypair->key_len))
+  if (!tls_mems_equal(left_tls_keypair->key_mem, right_tls_keypair->key_mem, left_tls_keypair->key_len, right_tls_keypair->key_len))
     return false;
   return true;
 }
@@ -795,7 +797,7 @@ tls_configs_equal(struct tls_config *tls_config_left, struct tls_config *tls_con
     return false;
   if (!strings_equal(tls_config_left->ca_path, tls_config_right->ca_path))
     return false;
-  if (!tls_mems_equal(tls_config_left->ca_mem, tls_config_right->ca_mem, tls_config_left->ca_len))
+  if (!tls_mems_equal(tls_config_left->ca_mem, tls_config_right->ca_mem, tls_config_left->ca_len, tls_config_right->ca_len))
     return false;
   if (!strings_equal(tls_config_left->ciphers, tls_config_right->ciphers))
     return false;
@@ -809,7 +811,7 @@ tls_configs_equal(struct tls_config *tls_config_left, struct tls_config *tls_con
     return false;
   if (!strings_equal(tls_config_left->ocsp_file, tls_config_right->ocsp_file))
     return false;
-  if (!tls_mems_equal(tls_config_left->ocsp_mem, tls_config_right->ocsp_mem, tls_config_left->ocsp_len))
+  if (!tls_mems_equal(tls_config_left->ocsp_mem, tls_config_right->ocsp_mem, tls_config_left->ocsp_len, tls_config_right->ocsp_len))
     return false;
   if (tls_config_left->protocols != tls_config_right->protocols)
     return false;

--- a/usual/tls/tls.h
+++ b/usual/tls/tls.h
@@ -164,7 +164,7 @@ int tls_ocsp_refresh_stapling_request(struct tls **ocsp_ctx_p, struct tls_config
 		char **ocsp_url, void **request_blob, size_t *request_size);
 
 int tls_ocsp_process_response(struct tls *ctx, const void *response_blob, size_t size);
-bool tls_configs_equal(struct tls_config *server_connect_conf_left, struct tls_config *server_connect_conf_right);
+bool tls_config_equal(struct tls_config *server_connect_conf_left, struct tls_config *server_connect_conf_right);
 
 #ifdef __cplusplus
 }

--- a/usual/tls/tls.h
+++ b/usual/tls/tls.h
@@ -164,6 +164,7 @@ int tls_ocsp_refresh_stapling_request(struct tls **ocsp_ctx_p, struct tls_config
 		char **ocsp_url, void **request_blob, size_t *request_size);
 
 int tls_ocsp_process_response(struct tls *ctx, const void *response_blob, size_t size);
+bool tls_configs_equal(struct tls_config *server_connect_conf_left, struct tls_config *server_connect_conf_right);
 
 #ifdef __cplusplus
 }

--- a/usual/tls/tls_config.c
+++ b/usual/tls/tls_config.c
@@ -58,13 +58,13 @@ set_mem(char **dest, size_t *destlen, const void *src, size_t srclen)
 	return 0;
 }
 
-static struct tls_keypair *
+struct tls_keypair *
 tls_keypair_new(void)
 {
 	return calloc(1, sizeof(struct tls_keypair));
 }
 
-static int
+int
 tls_keypair_set_cert_file(struct tls_keypair *keypair, const char *cert_file)
 {
 	return set_string(&keypair->cert_file, cert_file);

--- a/usual/tls/tls_internal.h
+++ b/usual/tls/tls_internal.h
@@ -178,6 +178,6 @@ int asn1_time_parse(const char *, size_t, struct tm *, int);
 
 struct tls_keypair * tls_keypair_new(void);
 int tls_keypair_set_cert_file(struct tls_keypair *keypair, const char *cert_file);
-bool keypair_list_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2);
+bool tls_keypair_list_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2);
 
 #endif /* HEADER_TLS_INTERNAL_H */

--- a/usual/tls/tls_internal.h
+++ b/usual/tls/tls_internal.h
@@ -176,4 +176,8 @@ int tls_asn1_parse_time(struct tls *ctx, const ASN1_TIME *asn1time, time_t *dst)
 
 int asn1_time_parse(const char *, size_t, struct tm *, int);
 
+struct tls_keypair * tls_keypair_new(void);
+int tls_keypair_set_cert_file(struct tls_keypair *keypair, const char *cert_file);
+bool keypair_list_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2);
+
 #endif /* HEADER_TLS_INTERNAL_H */


### PR DESCRIPTION
 In pgbouncer, we'd like to be able to compare TLS configs for equality to avoid over-aggressive connection recycling. Since knowledge about the structure for these configs live here it seems best to implement that here.

Original PR: https://github.com/pgbouncer/pgbouncer/pull/1157