### PR TITLE
Add time based logrotation

### DIFF
--- a/usual/logging.c
+++ b/usual/logging.c
@@ -189,7 +189,12 @@ void log_generic(enum LogLevel level, void *ctx, const char *fmt, ...)
 	format_time_ms(0, timebuf, sizeof(timebuf));
 
 	if (!log_file && cf_logfile && cf_logfile[0]) {
-		log_file = fopen(cf_logfile, "a");
+		char filename[80];
+		time_t rawtime;
+		struct tm *info;
+		info = localtime( &rawtime );
+		strftime(filename, 80, cf_logfile, info);
+		log_file = fopen(filename, "a");
 		if (log_file) {
 			/* Got the file, disable buffering */
 			setvbuf(log_file, NULL, _IONBF, 0);


### PR DESCRIPTION
This PR attempts to add a time based logrotation to pgbouncer. Basically it allows you to set a the cf_logfile to strftime based string which will enable pgbouncer to automatically change log files as appropriate.

I am open to other ways of doing this. Might be that it makes more sense to do this at the pgbouncer level: cache the config supplied cf_logfile value in another variable, render it periodically during some maintenance task, and set the rendered value to cf_logfile accordingly. Happy to make this change if needed.