### PR TITLE
Pthread Thread Local Storage support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -105,7 +105,7 @@ task:
 task:
   name: FreeBSD
   freebsd_instance:
-    image_family: freebsd-14-0
+    image_family: freebsd-14-2
   setup_script:
     - pkg install -y autoconf automake gmake libevent libtool pkgconf
   env:

--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,7 @@ PKG_CHECK_MODULES(LIBEVENT, libevent)
 
 AC_USUAL_GETADDRINFO_A
 
+AC_PTHREAD
 
 dnl search for common libraries
 # Required for infinite() on FreeBSD:

--- a/m4/usual.m4
+++ b/m4/usual.m4
@@ -345,14 +345,16 @@ AC_CACHE_CHECK([whether to use native getaddinfo_a], ac_cv_usual_glibc_gaia,
 
 if test x"$ac_cv_usual_glibc_gaia" = xyes ; then
   AC_DEFINE(HAVE_GETADDRINFO_A, 1, [Define to 1 if you have the getaddrinfo_a() function.])
-else
-  AX_PTHREAD(, [AC_MSG_RESULT([Threads not available and fallback getaddrinfo_a() non-functional.])])
-  CC="$PTHREAD_CC"
-  CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
-  LIBS="$LIBS $PTHREAD_LIBS"
 fi
 ])
 
+dnl Check and add -lpthread
+AC_DEFUN([AC_PTHREAD], [
+  AX_PTHREAD(, [AC_MSG_RESULT([Threads not available.])])
+  CC="$PTHREAD_CC"
+  CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+  LIBS="$LIBS $PTHREAD_LIBS"
+])
 
 dnl
 dnl  AC_USUAL_TLS:  --with-openssl [ / --with-gnutls ? ]

--- a/test/Makefile
+++ b/test/Makefile
@@ -27,6 +27,7 @@ regtest_system_SOURCES = \
 	test_netdb.c \
 	test_pgutil.c \
 	test_psrandom.c \
+	test_pthread.c \
 	test_regex.c \
 	test_shlist.c \
 	test_socket.c \

--- a/test/compile.c
+++ b/test/compile.c
@@ -16,6 +16,7 @@
 #include <usual/crypto/md5.h>
 #include <usual/crypto/csrandom.h>
 #include <usual/misc.h>
+#include <usual/pthread.h>
 #include <usual/safeio.h>
 #include <usual/shlist.h>
 #include <usual/signal.h>

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -29,6 +29,7 @@ struct testgroup_t groups[] = {
 	{ "netdb/", netdb_tests },
 	{ "pgutil/", pgutil_tests },
 	{ "psrandom/", psrandom_tests },
+	{ "pthread/", pthread_tests },
 	{ "regex/", regex_tests },
 	{ "shlist/", shlist_tests },
 	{ "socket/", socket_tests },

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -45,6 +45,7 @@ extern struct testcase_t mdict_tests[];
 extern struct testcase_t netdb_tests[];
 extern struct testcase_t pgutil_tests[];
 extern struct testcase_t psrandom_tests[];
+extern struct testcase_t pthread_tests[];
 extern struct testcase_t regex_tests[];
 extern struct testcase_t shlist_tests[];
 extern struct testcase_t socket_tests[];

--- a/test/test_pthread.c
+++ b/test/test_pthread.c
@@ -1,0 +1,78 @@
+#include "test_common.h"
+#include <usual/pthread.h>
+
+
+#define NUM_THREADS 4
+static pthread_mutex_t lock;
+static int shared_counter = 0;
+
+static void *lock_func(void *arg) {
+    pthread_mutex_lock(&lock);
+    shared_counter += 1;
+    pthread_mutex_unlock(&lock);
+    return NULL;
+}
+
+static void test_pthread_mutex(void *p) {
+    pthread_t threads[NUM_THREADS];
+
+    tt_assert(pthread_mutex_init(&lock, NULL) == 0);
+
+    for (int i = 0; i < NUM_THREADS; i++) {
+        tt_assert(pthread_create(&threads[i], NULL, lock_func, NULL) == 0);
+    }
+
+    for (int i = 0; i < NUM_THREADS; i++) {
+        tt_assert(pthread_join(threads[i], NULL) == 0);
+    }
+
+    tt_assert(shared_counter == NUM_THREADS);
+
+    pthread_mutex_destroy(&lock);
+    return;
+end:;
+}
+
+
+static int thread_data[NUM_THREADS];
+static pthread_key_t test_key;
+
+static void test_pthread_key_destructor(void *value) {
+    free(value);
+}
+
+static void *test_pthread_key_func(void *arg) {
+    int thread_index = *(int *)arg;
+    int *thread_specific_value = malloc(sizeof(int));
+    *thread_specific_value = thread_index;
+    pthread_setspecific(test_key, thread_specific_value);
+    usleep(1000);
+    int *retrieved = pthread_getspecific(test_key);
+    thread_data[thread_index] = *retrieved;
+    return NULL;
+}
+
+static void test_pthread_key(void *p) {
+    tt_assert(pthread_key_create(&test_key, test_pthread_key_destructor) == 0);
+    pthread_t threads[NUM_THREADS];
+    for (int i = 0; i < NUM_THREADS; i++) {
+        thread_data[i] = i;
+        tt_assert(pthread_create(&threads[i], NULL, test_pthread_key_func, &thread_data[i]) == 0);
+    }
+    for (int i = 0; i < NUM_THREADS; i++) {
+        tt_assert(pthread_join(threads[i], NULL) == 0);
+    }
+    for (int i = 0; i < NUM_THREADS; i++) {
+        tt_assert(thread_data[i] == i);
+    }
+    tt_assert(pthread_key_delete(test_key) == 0);
+    return;
+end:;
+}
+
+
+struct testcase_t pthread_tests[] = {
+    { "pthread_mutex", test_pthread_mutex },
+    { "pthread_key", test_pthread_key },
+    END_OF_TESTCASES
+};

--- a/test/test_pthread.c
+++ b/test/test_pthread.c
@@ -44,17 +44,22 @@ static void test_pthread_key_destructor(void *value) {
 static void *test_pthread_key_func(void *arg) {
     int thread_index = *(int *)arg;
     int *thread_specific_value = malloc(sizeof(int));
+    int *retrieved;
+
     *thread_specific_value = thread_index;
     pthread_setspecific(test_key, thread_specific_value);
     usleep(1000);
-    int *retrieved = pthread_getspecific(test_key);
+
+    retrieved = pthread_getspecific(test_key);
     thread_data[thread_index] = *retrieved;
     return NULL;
 }
 
 static void test_pthread_key(void *p) {
-    tt_assert(pthread_key_create(&test_key, test_pthread_key_destructor) == 0);
     pthread_t threads[NUM_THREADS];
+    
+    tt_assert(pthread_key_create(&test_key, test_pthread_key_destructor) == 0);
+    
     for (int i = 0; i < NUM_THREADS; i++) {
         thread_data[i] = i;
         tt_assert(pthread_create(&threads[i], NULL, test_pthread_key_func, &thread_data[i]) == 0);

--- a/usual/pthread.c
+++ b/usual/pthread.c
@@ -38,7 +38,7 @@ static DWORD WINAPI w32launcher(LPVOID arg)
 	return 0;
 }
 
-int pthread_create(pthread_t *t, pthread_attr_t *attr, void *(*fn)(void *), void *arg)
+int compat_pthread_create(pthread_t *t, pthread_attr_t *attr, void *(*fn)(void *), void *arg)
 {
 	struct _w32thread *info = calloc(1, sizeof(*info));
 	if (!info)
@@ -51,7 +51,7 @@ int pthread_create(pthread_t *t, pthread_attr_t *attr, void *(*fn)(void *), void
 	return 0;
 }
 
-int pthread_join(pthread_t *t, void **ret)
+int compat_pthread_join(pthread_t *t, void **ret)
 {
 	if (WaitForSingleObject(*t, INFINITE) != WAIT_OBJECT_0)
 		return -1;
@@ -59,7 +59,7 @@ int pthread_join(pthread_t *t, void **ret)
 	return 0;
 }
 
-int pthread_mutex_init(pthread_mutex_t *lock, void *unused)
+int compat_pthread_mutex_init(pthread_mutex_t *lock, void *unused)
 {
 	*lock = CreateMutex(NULL, FALSE, NULL);
 	if (*lock == NULL)
@@ -67,7 +67,7 @@ int pthread_mutex_init(pthread_mutex_t *lock, void *unused)
 	return 0;
 }
 
-int pthread_mutex_destroy(pthread_mutex_t *lock)
+int compat_pthread_mutex_destroy(pthread_mutex_t *lock)
 {
 	if (*lock) {
 		CloseHandle(*lock);
@@ -76,37 +76,42 @@ int pthread_mutex_destroy(pthread_mutex_t *lock)
 	return 0;
 }
 
-int pthread_mutex_lock(pthread_mutex_t *lock)
+int compat_pthread_mutex_lock(pthread_mutex_t *lock)
 {
 	if (WaitForSingleObject(*lock, INFINITE) != WAIT_OBJECT_0)
 		return -1;
 	return 0;
 }
 
-int pthread_mutex_unlock(pthread_mutex_t *lock)
+int compat_pthread_mutex_unlock(pthread_mutex_t *lock)
 {
 	if (!ReleaseMutex(*lock))
 		return -1;
 	return 0;
 }
 
-#ifdef INIT_ONCE_STATIC_INIT
-
-typedef void (*once_posix_cb_t)(void);
-
-static BOOL once_wrapper(PINIT_ONCE once, void *arg, void **ctx)
+int compat_pthread_key_create(pthread_key_t *key, void (*destructor)(void*))
 {
-	once_posix_cb_t cb = arg;
-	arg();
-	return TRUE;
+	if (!key) return EINVAL;
+	*key = TlsAlloc();
+    return (*key == TLS_OUT_OF_INDEXES) ? EINVAL : 0;
 }
 
-int pthread_once(pthread_once_t *once, void (*once_func)(void))
+int compat_pthread_key_delete(pthread_key_t key)
 {
-	return InitOnceExecuteOnce(once, once_wrapper, once_func, NULL) ? 0 : -1;
+	return FlsFree(key) == true ? 0 : EINVAL;
 }
 
-#endif
+void* compat_pthread_getspecific(pthread_key_t key)
+{
+	return TlsGetValue(key);
+}
+
+int compat_pthread_setspecific(pthread_key_t key, const void *value)
+{
+	return TlsSetValue(key, (LPVOID)value) ? 0 : EINVAL;
+}
+
 
 
 #endif /* win32 */

--- a/usual/pthread.c
+++ b/usual/pthread.c
@@ -94,7 +94,7 @@ int compat_pthread_key_create(pthread_key_t *key, void (*destructor)(void*))
 {
 	if (!key) return EINVAL;
 	*key = TlsAlloc();
-    return (*key == TLS_OUT_OF_INDEXES) ? EINVAL : 0;
+	return (*key == TLS_OUT_OF_INDEXES) ? EINVAL : 0;
 }
 
 int compat_pthread_key_delete(pthread_key_t key)

--- a/usual/pthread.h
+++ b/usual/pthread.h
@@ -36,24 +36,28 @@
 #define pthread_mutex_lock(a)		compat_pthread_mutex_lock(a)
 #define pthread_mutex_unlock(a)		compat_pthread_mutex_unlock(a)
 #define pthread_join(a,b)		compat_pthread_join(a,b)
-#define pthread_once(a,b)		compat_pthread_once(a,b)
+#define pthread_key_create(a,b)     compat_pthread_key_create(a,b)
+#define pthread_key_delete(a)       compat_pthread_key_delete(a)
+#define pthread_getspecific(a)      compat_pthread_getspecific(a)
+#define pthread_setspecific(a,b)    compat_pthread_setspecific(a,b)
 
 typedef HANDLE pthread_t;
 typedef HANDLE pthread_mutex_t;
 typedef int pthread_attr_t;
+typedef DWORD pthread_key_t;
 
-int pthread_create(pthread_t *t, pthread_attr_t *attr, void *(*fn)(void *), void *arg);
-int pthread_mutex_init(pthread_mutex_t *lock, void *unused);
-int pthread_mutex_destroy(pthread_mutex_t *lock);
-int pthread_mutex_lock(pthread_mutex_t *lock);
-int pthread_mutex_unlock(pthread_mutex_t *lock);
-int pthread_join(pthread_t *t, void **ret);
+int compat_pthread_create(pthread_t *t, pthread_attr_t *attr, void *(*fn)(void *), void *arg);
+int compat_pthread_mutex_init(pthread_mutex_t *lock, void *unused);
+int compat_pthread_mutex_destroy(pthread_mutex_t *lock);
+int compat_pthread_mutex_lock(pthread_mutex_t *lock);
+int compat_pthread_mutex_unlock(pthread_mutex_t *lock);
+int compat_pthread_join(pthread_t *t, void **ret);
+int compat_pthread_key_create(pthread_key_t *key, void (*destructor)(void*));
+int compat_pthread_key_delete(pthread_key_t key);
+void* compat_pthread_getspecific(pthread_key_t key);
+int compat_pthread_setspecific(pthread_key_t key, const void *value);
 
-#ifdef INIT_ONCE_STATIC_INIT
-#define PTHREAD_ONCE_INIT INIT_ONCE_STATIC_INIT
-typedef INIT_ONCE pthread_once_t;
-int pthread_once(pthread_once_t *once, void (*once_func)(void));
-#endif
+
 
 #endif /* WIN32 */
 


### PR DESCRIPTION
To support multithreading in pgbouncer, this PR enables thread-local storage in usual/pthread. It also adds unit tests for pthread.h and fixes bugs encountered in the win32 environment.

coworker: @Beihao-Zhou