### PR TITLE
Fix unit test and CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -105,7 +105,7 @@ task:
 task:
   name: FreeBSD
   freebsd_instance:
-    image_family: freebsd-14-0
+    image_family: freebsd-14-2
   setup_script:
     - pkg install -y autoconf automake gmake libevent libtool pkgconf
   env:

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -4,6 +4,7 @@
 #include "tinytest_macros.h"
 
 #define str_check(a, b) tt_str_op(a, ==, b)
+#define str_contains_check(a, b) tt_str_contains_op(a, "has", b)
 #define int_check(a, b) tt_int_op(a, ==, b)
 #define ull_check(a, b) tt_assert_op_type(a, ==, b, uint64_t, "%" PRIu64)
 

--- a/test/test_tls.c
+++ b/test/test_tls.c
@@ -778,7 +778,7 @@ static void test_clientcert(void *z)
 				"verify-client=1",
 				NULL), "OK");
 	str_check(create_worker(&client, false, CA1, "host=server1.com", NULL), "OK");
-	str_check(run_case(client, server), "C:sslv3 alert handshake failure - S:peer did not return a certificate");
+	str_contains_check(run_case(client, server), "alert handshake failure - S:peer did not return a certificate");
 
 	/* verify-client-optional: allow client without cert */
 	str_check(create_worker(&server, true, SERVER1, CA2,
@@ -815,8 +815,8 @@ static void test_fingerprint(void *z)
 		"peer-sha256=ssl/ca2_client2.crt.sha256",
 		NULL), "OK");
 	str_check(create_worker(&client, false, CA1, "host=server1.com", NULL), "OK");
-	str_check(run_case(client, server),
-		 "C:sslv3 alert handshake failure - S:peer did not return a certificate");
+	str_contains_check(run_case(client, server),
+		 " alert handshake failure - S:peer did not return a certificate");
 end:;
 }
 

--- a/test/tinytest_macros.h
+++ b/test/tinytest_macros.h
@@ -142,4 +142,7 @@
 	tt_assert_test_type(a,b,#a" "#op" "#b,const char *,		\
 			    (strcmp(_val1,_val2) op 0),"<%s>")
 
+#define tt_str_contains_op(a,op,b)						\
+	tt_assert_test_type(a,b,#a" "#op" "#b,const char *,		\
+			    (strstr(_val1,_val2) != NULL),"<%s>")
 #endif


### PR DESCRIPTION
This PR fixs tls unit test and CI.
The CI is broken because:
1. FreeBSD image not found, [example](https://github.com/libusual/libusual/runs/37664000964).
2. tls test on Linux (Red Hat) container:rockylinux:9 not correct, [example](https://github.com/libusual/libusual/pull/64/checks?check_run_id=37664121141).