### PR TITLE
Add Context Support to Thread-Safe Stat List Iterators

### DIFF
--- a/test/test_statlist_ts.c
+++ b/test/test_statlist_ts.c
@@ -88,6 +88,7 @@ static void count_elements(struct List *item, void *ctx) {
 static void test_thread_safe_statlist_iteration(void *p) {
     struct ThreadSafeStatList ts_list;
     struct List node1, node2, node3;
+    int element_count;
 
     thread_safe_statlist_init(&ts_list, "test_list_iteration");
 
@@ -99,7 +100,7 @@ static void test_thread_safe_statlist_iteration(void *p) {
     thread_safe_statlist_append(&ts_list, &node2);
     thread_safe_statlist_append(&ts_list, &node3);
 
-    int element_count = 0;
+    element_count = 0;
     thread_safe_statlist_iterate(&ts_list, count_elements, &element_count);
     str_check(element_count == 3 ? "OK" : "FAIL", "OK");
 

--- a/test/test_statlist_ts.c
+++ b/test/test_statlist_ts.c
@@ -80,10 +80,9 @@ end:;
 
 
 /* iteration */
-
-static int element_count = 0;
-static void count_elements(struct List *item) {
-    element_count++;
+static void count_elements(struct List *item, void *ctx) {
+    int *counter = (int *)ctx;
+    (*counter)++;
 }
 
 static void test_thread_safe_statlist_iteration(void *p) {
@@ -91,7 +90,7 @@ static void test_thread_safe_statlist_iteration(void *p) {
     struct List node1, node2, node3;
 
     thread_safe_statlist_init(&ts_list, "test_list_iteration");
-    
+
     list_init(&node1);
     list_init(&node2);
     list_init(&node3);
@@ -100,12 +99,12 @@ static void test_thread_safe_statlist_iteration(void *p) {
     thread_safe_statlist_append(&ts_list, &node2);
     thread_safe_statlist_append(&ts_list, &node3);
 
-    element_count = 0;
-    thread_safe_statlist_iterate(&ts_list, count_elements);
+    int element_count = 0;
+    thread_safe_statlist_iterate(&ts_list, count_elements, &element_count);
     str_check(element_count == 3 ? "OK" : "FAIL", "OK");
 
     element_count = 0;
-    thread_safe_statlist_iterate_reverse(&ts_list, count_elements);
+    thread_safe_statlist_iterate_reverse(&ts_list, count_elements, &element_count);
     str_check(element_count == 3 ? "OK" : "FAIL", "OK");
 
 end:;

--- a/usual/statlist_ts.h
+++ b/usual/statlist_ts.h
@@ -100,22 +100,30 @@ static inline void thread_safe_statlist_put_after(struct ThreadSafeStatList *lis
     spin_lock_release(&list->lock);
 }
 
-/** Loop over thread-safe list */
-static inline void thread_safe_statlist_iterate(struct ThreadSafeStatList *list, void (*func)(struct List *)) {
+/** Loop over thread-safe list (with context) */
+static inline void thread_safe_statlist_iterate(
+    struct ThreadSafeStatList *list,
+    void (*func)(struct List *, void *),
+    void *ctx)
+{
     struct List *item;
     spin_lock_acquire(&list->lock);
     statlist_for_each(item, &list->list) {
-        func(item);
+        func(item, ctx);
     }
     spin_lock_release(&list->lock);
 }
 
-/** Loop over thread-safe list backwards */
-static inline void thread_safe_statlist_iterate_reverse(struct ThreadSafeStatList *list, void (*func)(struct List *)) {
+/** Loop over thread-safe list backwards (with context) */
+static inline void thread_safe_statlist_iterate_reverse(
+    struct ThreadSafeStatList *list,
+    void (*func)(struct List *, void *),
+    void *ctx)
+{
     struct List *item;
     spin_lock_acquire(&list->lock);
     statlist_for_each_reverse(item, &list->list) {
-        func(item);
+        func(item, ctx);
     }
     spin_lock_release(&list->lock);
 }


### PR DESCRIPTION
This PR updates the `thread_safe_statlist_iterate` and `thread_safe_statlist_iterate_reverse` functions to support passing a `void *ctx` context parameter to the iteration callback. Previously, iterating over a `ThreadSafeStatList` with per-call context (e.g., a counter or flag) required using static/global variables, which are error-prone and not thread-safe. This change enables more flexible and reusable callbacks without relying on static/global state.

coworker: @GuanqunYang193 