### PR TITLE
Add support to set ciphers for TLSv1.3

### DIFF
--- a/test/connect-tls.c
+++ b/test/connect-tls.c
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
 		errx(1, "tls_config_new");
 
 	tls_config_set_protocols(conf, TLS_PROTOCOLS_ALL);
-	tls_config_set_ciphers(conf, "fast");
+	tls_config_set_ciphers(conf, "fast", NULL);
 
 	ctx = tls_client();
 	if (!ctx)

--- a/test/test_tls.c
+++ b/test/test_tls.c
@@ -219,7 +219,9 @@ static const char *create_worker(struct Worker **w_p, int is_server, ...)
 		} else if (!strncmp(k, "show=", klen)) {
 			w->show = v;
 		} else if (!strncmp(k, "ciphers=", klen)) {
-			err = tls_config_set_ciphers(w->config, v);
+			err = tls_config_set_ciphers(w->config, v, NULL);
+		} else if (!strncmp(k, "ciphers13=", klen)) {
+			err = tls_config_set_ciphers(w->config, NULL, v);
 		} else if (!strncmp(k, "host=", klen)) {
 			w->hostname = v;
 		} else if (!strncmp(k, "noverifycert=", klen)) {
@@ -455,7 +457,7 @@ static const char *done_handshake(struct Worker *w)
 		return emsg;
 
 	if (w->show) {
-		if (strcmp(w->show, "ciphers") == 0) {
+		if (strcmp(w->show, "ciphers") == 0 || strcmp(w->show, "ciphers13") == 0) {
 			tls_get_connection_info(w->ctx, w->showbuf, sizeof w->showbuf);
 		} else if (strcmp(w->show, "peer-cert") == 0) {
 			struct tls_cert *cert = NULL;
@@ -833,6 +835,46 @@ static void test_set_mem(void *z)
 end:;
 }
 
+static void test_cipher_tlsv12(void *z)
+{
+	struct Worker *server = NULL, *client = NULL;
+
+	tt_assert(tls_init() == 0);
+
+	str_check(create_worker(&server, true,
+		"protocols=tlsv1.2",
+		"ciphers=AES128+SHA256",
+		"show=ciphers",
+		SERVER1, NULL), "OK");
+	str_check(create_worker(&client, false, CA1,
+		"protocols=tlsv1.2",
+		"host=server1.com",
+		NULL), "OK");
+	str_check(run_case(client, server),
+		 "TLSv1.2/ECDHE-ECDSA-AES128-SHA256/ECDH=X25519");
+	end:;
+}
+
+static void test_cipher_tlsv13(void *z)
+{
+	struct Worker *server = NULL, *client = NULL;
+
+	tt_assert(tls_init() == 0);
+
+	str_check(create_worker(&server, true,
+		"protocols=tlsv1.3",
+		"ciphers13=TLS_CHACHA20_POLY1305_SHA256",
+		"show=ciphers13",
+		SERVER1, NULL), "OK");
+	str_check(create_worker(&client, false, CA1,
+		"protocols=tlsv1.3",
+		"host=server1.com",
+		NULL), "OK");
+	str_check(run_case(client, server),
+		 "TLSv1.3/TLS_CHACHA20_POLY1305_SHA256");
+	end:;
+}
+
 static void test_cipher_nego(void *z)
 {
 	struct Worker *server = NULL, *client = NULL;
@@ -1099,6 +1141,8 @@ struct testcase_t tls_tests[] = {
 	{ "clientcert", test_clientcert },
 	{ "fingerprint", test_fingerprint },
 	{ "set-mem", test_set_mem },
+	{ "cipher-tlsv12", test_cipher_tlsv12 },
+	{ "cipher-tlsv13", test_cipher_tlsv13 },
 	{ "cipher-nego", test_cipher_nego },
 	{ "cert-info", test_cert_info },
 	{ "tls_config_equal", test_tls_config_equal },

--- a/usual/tls/tls.c
+++ b/usual/tls/tls.c
@@ -475,11 +475,26 @@ tls_configure_ssl(struct tls *ctx)
 
 			if (SSL_CTX_set_cipher_list(ctx->ssl_ctx,
 				ctx->config->ciphers) != 1) {
-					tls_set_errorx(ctx, "failed to set ciphers");
+					tls_set_errorx(ctx, "failed to set the TLSv1.2 ciphers list");
 					goto err;
 			}
 		}
 	}
+
+	/*
+	 * Set up the allowed cipher suites for TLSv1.3. If the value is an empty
+	 * string or NULL we leave the allowed suites to be the OpenSSL default value.
+	 */
+	if (ctx->config->protocols & TLS_PROTOCOL_TLSv1_3 &&
+	    ctx->config->cipher_suites != NULL &&
+	    strlen(ctx->config->cipher_suites) > 0)
+	{
+		if(SSL_CTX_set_ciphersuites(ctx->ssl_ctx, ctx->config->cipher_suites) != 1) {
+			tls_set_errorx(ctx, "failed to set the TLSv1.3 cipher suites");
+			goto err;
+		}
+	}
+
 	SSL_CTX_set_info_callback(ctx->ssl_ctx, tls_info_callback);
 
 #ifdef X509_V_FLAG_NO_CHECK_TIME

--- a/usual/tls/tls.h
+++ b/usual/tls/tls.h
@@ -85,7 +85,7 @@ int tls_config_set_cert_file(struct tls_config *_config,
     const char *_cert_file);
 int tls_config_set_cert_mem(struct tls_config *_config, const uint8_t *_cert,
     size_t _len);
-int tls_config_set_ciphers(struct tls_config *_config, const char *_ciphers);
+int tls_config_set_ciphers(struct tls_config *_config, const char *_ciphers, const char *_cipher_suites);
 int tls_config_set_dheparams(struct tls_config *_config, const char *_params);
 int tls_config_set_ecdhecurve(struct tls_config *_config, const char *_name);
 int tls_config_set_key_file(struct tls_config *_config, const char *_key_file);

--- a/usual/tls/tls_config.c
+++ b/usual/tls/tls_config.c
@@ -135,7 +135,7 @@ tls_config_new(void)
 		goto err;
 	if (tls_config_set_ecdhecurve(config, "auto") != 0)
 		goto err;
-	if (tls_config_set_ciphers(config, "secure") != 0)
+	if (tls_config_set_ciphers(config, "secure", NULL) != 0)
 		goto err;
 
 	tls_config_set_protocols(config, TLS_PROTOCOLS_DEFAULT);
@@ -283,9 +283,20 @@ tls_config_set_cert_mem(struct tls_config *config, const uint8_t *cert,
 }
 
 int
-tls_config_set_ciphers(struct tls_config *config, const char *ciphers)
+tls_config_set_ciphers(struct tls_config *config, const char *ciphers, const char *cipher_suites)
 {
 	SSL_CTX *ssl_ctx = NULL;
+
+	/*
+	 * Set up the allowed cipher suites for TLSv1.3. If the value is an empty
+	 * string or NULL we leave the allowed suites to be the OpenSSL default value.
+	 */
+	if (config->protocols & TLS_PROTOCOL_TLSv1_3 &&
+	     (cipher_suites != NULL && strlen(cipher_suites) > 0))
+	{
+	     if (set_string(&config->cipher_suites, cipher_suites) != 0)
+		     return -1;
+	}
 
 	/*
 	 * obsolete outdated keywords, turn them to default.
@@ -312,7 +323,7 @@ tls_config_set_ciphers(struct tls_config *config, const char *ciphers)
 		goto fail;
 	}
 	if (SSL_CTX_set_cipher_list(ssl_ctx, ciphers) != 1) {
-		tls_config_set_errorx(config, "no ciphers for '%s'", ciphers);
+		tls_config_set_errorx(config, "no ciphers of TLSv1.2 for '%s'", ciphers);
 		goto fail;
 	}
 

--- a/usual/tls/tls_internal.h
+++ b/usual/tls/tls_internal.h
@@ -53,7 +53,8 @@ struct tls_config {
 	const char *ca_path;
 	char *ca_mem;
 	size_t ca_len;
-	const char *ciphers;
+	const char *ciphers; /* For TLS v1.2 or older */
+	const char *cipher_suites; /* For TLS v1.3 */
 	int ciphers_server;
 	int dheparams;
 	int ecdhecurve;

--- a/usual/tls/tls_util.c
+++ b/usual/tls/tls_util.c
@@ -191,7 +191,11 @@ tls_get_connection_info(struct tls *ctx, char *buf, size_t buflen)
 
 	if (conn != NULL) {
 		proto = SSL_get_version(conn);
-		cipher = SSL_get_cipher(conn);
+		if (strcmp(proto, "TLSv1.3") == 0)
+			cipher = SSL_get_cipher_list(conn, 0);
+		else
+			cipher = SSL_get_cipher(conn);
+
 		ciph_obj = SSL_get_current_cipher(conn);
 
 #ifdef SSL_get_server_tmp_key


### PR DESCRIPTION
Currently on PgBouncer it's not possible to set ciphers for TLS v1.3. This is
because for TLS v1.3 we need to use a different API to set the ciphers, e.g:
```
client_tls_protocols=tlsv1.3
client_tls_ciphers=TLS_CHACHA20_POLY1305_SHA256
client_tls_sslmode=require
```

When connect using `psql` we get:
`SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off, ALPN: none)`

This PR change the `tls_config_set_ciphers` to receive an optional ciphers_suites
parameter to set on `tls_config` so that it can be used later on
`tls_configure_ssl` to call the new OpenSSL API to set the v1.3 ciphers.

Once we get this committed, I'll update the PgBouncer code to add a config for
the TLS v1.3 ciphers to pass through the tls_config_set_ciphers function.

---
Some open questions:

On `tls_config_set_ciphers` I'm only setting the cipher_suites on tls_config,
and I'm not sure if I also should call the `SSL_CTX_set_ciphersuites` for TLS
v1.3 as this function also call the `SSL_CTX_set_cipher_list` for TLS v1.2 or
older.

I've hard-coded the priority parameter value from `SSL_get_cipher_list` on
usual/tls/tls_util.c and I'm not sure if we need to make this configurable or
use another value.
