### PR TITLE
Add recursive spinlock using atomic thread ID ownership

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "__locale": "cpp",
+        "locale": "cpp"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "files.associations": {
-        "__locale": "cpp",
-        "locale": "cpp"
-    }
-}

--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,7 @@ AC_PTHREAD
 dnl search for common libraries
 # Required for infinite() on FreeBSD:
 AC_CHECK_LIB(m, main)
+AC_CHECK_FUNCS([pthread_threadid_np])
 AC_SEARCH_LIBS(clock_gettime, rt)
 AC_SEARCH_LIBS(getsockname, socket)
 AC_SEARCH_LIBS(gethostbyname, nsl)

--- a/test/test_slab_ts.c
+++ b/test/test_slab_ts.c
@@ -12,7 +12,7 @@ static void test_slab(void *p)
     struct ThreadSafeSlab *ts_slab;
     void *obj1, *obj2;
 
-    ts_slab = thread_safe_slab_create("test_slab", sizeof(int), 0, NULL, NULL);
+    ts_slab = thread_safe_slab_create("test_slab", sizeof(int), 0, NULL, NULL, false);
     tt_assert(ts_slab != NULL);
 
     obj1 = thread_safe_slab_alloc(ts_slab);
@@ -56,7 +56,7 @@ static void test_slab_multithreaded(void *p) {
     pthread_t threads[NUM_THREADS];
     int call_count = 0;
     
-    ts_slab = thread_safe_slab_create("test_slab_mt", sizeof(int), 0, NULL, NULL);
+    ts_slab = thread_safe_slab_create("test_slab_mt", sizeof(int), 0, NULL, NULL, false);
     tt_assert(ts_slab != NULL);
 
     for (int i = 0; i < NUM_THREADS; i++) {
@@ -75,10 +75,10 @@ static void test_slab_multithreaded(void *p) {
     tt_assert(thread_safe_slab_free_count(ts_slab) == thread_safe_slab_total_count(ts_slab));
     tt_assert(thread_safe_slab_active_count(ts_slab) == 0);
 
-    ts_slab1 = thread_safe_slab_create("stats_slab_1", sizeof(int), 0, NULL, NULL);
+    ts_slab1 = thread_safe_slab_create("stats_slab_1", sizeof(int), 0, NULL, NULL, false);
     tt_assert(ts_slab1);
 
-    ts_slab2 = thread_safe_slab_create("stats_slab_2", sizeof(int), 0, NULL, NULL);
+    ts_slab2 = thread_safe_slab_create("stats_slab_2", sizeof(int), 0, NULL, NULL, false);
     tt_assert(ts_slab2);
 
     obj1 = thread_safe_slab_alloc(ts_slab1);

--- a/test/test_spinlock.c
+++ b/test/test_spinlock.c
@@ -13,12 +13,6 @@ static void test_spin_lock_basic(void *p)
     spin_lock_acquire(&lock);
     int_check(lock.count, 1);
 
-    spin_lock_acquire(&lock);
-    int_check(lock.count, 2);
-
-    spin_lock_release(&lock);
-    int_check(lock.count, 1);
-
     spin_lock_release(&lock);
     int_check(lock.count, 0);
 
@@ -96,7 +90,7 @@ static void test_spin_lock_recursive(void *p)
 {
     pthread_t threads[NUM_RECURSIVE_THREADS];
     spin_lock_init(&recursive_lock);
-
+    set_recursive(&recursive_lock, true);
     for (int i = 0; i < NUM_RECURSIVE_THREADS; i++) {
         pthread_create(&threads[i], NULL, recursive_thread_function, NULL);
     }

--- a/test/test_spinlock.c
+++ b/test/test_spinlock.c
@@ -11,10 +11,16 @@ static void test_spin_lock_basic(void *p)
     spin_lock_init(&lock);
 
     spin_lock_acquire(&lock);
-    int_check(lock.lock, 1);
+    int_check(lock.count, 1);
+
+    spin_lock_acquire(&lock);
+    int_check(lock.count, 2);
 
     spin_lock_release(&lock);
-    int_check(lock.lock, 0);
+    int_check(lock.count, 1);
+
+    spin_lock_release(&lock);
+    int_check(lock.count, 0);
 
 end:;
 }
@@ -42,7 +48,6 @@ static void test_spin_lock_multithreaded(void *p)
 {
     pthread_t threads[NUM_THREADS];
     spin_lock_init(&shared_lock);
-    shared_counter = 0;
 
     for (int i = 0; i < NUM_THREADS; i++) {
         pthread_create(&threads[i], NULL, thread_function, NULL);
@@ -56,11 +61,61 @@ static void test_spin_lock_multithreaded(void *p)
 end:;
 }
 
+
+/*
+ * Multithreaded recursive locking test
+ * Each thread acquires the lock 3 times recursively,
+ * then releases it the same number of times.
+ */
+#define NUM_RECURSIVE_THREADS 5
+#define RECURSIVE_DEPTH 3
+#define NUM_RECURSIVE_ITERATIONS 1000
+
+static SpinLock recursive_lock;
+static int recursive_counter = 0;
+
+static void *recursive_thread_function(void *arg)
+{
+    for (int i = 0; i < NUM_RECURSIVE_ITERATIONS; i++) {
+        // Acquire the lock recursively
+        for (int d = 0; d < RECURSIVE_DEPTH; d++) {
+            spin_lock_acquire(&recursive_lock);
+        }
+
+        recursive_counter++;
+
+        // Release the lock in reverse
+        for (int d = 0; d < RECURSIVE_DEPTH; d++) {
+            spin_lock_release(&recursive_lock);
+        }
+    }
+    return NULL;
+}
+
+static void test_spin_lock_recursive(void *p)
+{
+    pthread_t threads[NUM_RECURSIVE_THREADS];
+    spin_lock_init(&recursive_lock);
+
+    for (int i = 0; i < NUM_RECURSIVE_THREADS; i++) {
+        pthread_create(&threads[i], NULL, recursive_thread_function, NULL);
+    }
+
+    for (int i = 0; i < NUM_RECURSIVE_THREADS; i++) {
+        pthread_join(threads[i], NULL);
+    }
+
+    int_check(recursive_counter, NUM_RECURSIVE_THREADS * NUM_RECURSIVE_ITERATIONS);
+end:;
+}
+
+
 /*
  * Describe test cases
  */
 struct testcase_t spinlock_tests[] = {
     { "basic", test_spin_lock_basic },
     { "multithread", test_spin_lock_multithreaded },
+    { "recursive", test_spin_lock_recursive },
     END_OF_TESTCASES
 };

--- a/test/test_statlist_ts.c
+++ b/test/test_statlist_ts.c
@@ -9,7 +9,7 @@ static void test_thread_safe_statlist_simple(void *p) {
     struct List node1, node2, node3;
     struct List *popped_node;
 
-    thread_safe_statlist_init(&ts_list, "test_list");
+    thread_safe_statlist_init(&ts_list, "test_list", false);
 
     spin_lock_acquire(&ts_list.lock);
     str_check(statlist_count(&ts_list.list) == 0 ? "OK" : "FAIL", "OK");
@@ -60,7 +60,7 @@ static void *thread_worker(void *arg) {
 
 static void test_thread_safe_statlist_multithreaded(void *p) {
     pthread_t threads[NUM_THREADS];
-    thread_safe_statlist_init(&ts_list, "test_list");
+    thread_safe_statlist_init(&ts_list, "test_list", false);
     srand(time(NULL));
 
     for (int i = 0; i < NUM_THREADS; i++) {
@@ -90,7 +90,7 @@ static void test_thread_safe_statlist_iteration(void *p) {
     struct List node1, node2, node3;
     int element_count;
 
-    thread_safe_statlist_init(&ts_list, "test_list_iteration");
+    thread_safe_statlist_init(&ts_list, "test_list_iteration", false);
 
     list_init(&node1);
     list_init(&node2);

--- a/usual/slab_ts.c
+++ b/usual/slab_ts.c
@@ -9,7 +9,7 @@ static struct ThreadSafeStatList thread_safe_slab_list;
 
 __attribute__((constructor))
 static void init_thread_safe_slab_list_global(void) {
-    thread_safe_statlist_init(&thread_safe_slab_list, "thread_safe_slab_list");
+    thread_safe_statlist_init(&thread_safe_slab_list, "thread_safe_slab_list", true);
 }
 
 /*
@@ -41,7 +41,7 @@ static void init_thread_safe_slab_and_store_in_list(struct ThreadSafeSlab *ts_sl
 
 /* create a new thread-safe slab allocator */
 struct ThreadSafeSlab *thread_safe_slab_create(const char *name, unsigned obj_size, unsigned align,
-                                               slab_init_fn init_func, CxMem *cx) {
+                                               slab_init_fn init_func, CxMem *cx, bool enable_recursive_lock) {
     struct ThreadSafeSlab *ts_slab;
 
     ts_slab = cx ? cx_alloc0(cx, sizeof(*ts_slab)) : calloc(1, sizeof(*ts_slab));
@@ -58,6 +58,7 @@ struct ThreadSafeSlab *thread_safe_slab_create(const char *name, unsigned obj_si
     list_init(&ts_slab->head);
     init_thread_safe_slab_and_store_in_list(ts_slab, name, obj_size, align, init_func, cx);
     spin_lock_init(&ts_slab->lock);
+    set_recursive(&ts_slab->lock, enable_recursive_lock);
     return ts_slab;
 }
 

--- a/usual/slab_ts.h
+++ b/usual/slab_ts.h
@@ -13,7 +13,7 @@ struct ThreadSafeSlab;
 
 /* Create a new thread-safe slab context */
 struct ThreadSafeSlab *thread_safe_slab_create(const char *name, unsigned obj_size, unsigned align,
-                                               slab_init_fn init_func, CxMem *cx);
+                                               slab_init_fn init_func, CxMem *cx, bool enable_recursive_lock);
 
 /* Destroy a thread-safe slab context */
 void thread_safe_slab_destroy(struct ThreadSafeSlab *ts_slab);

--- a/usual/spinlock.c
+++ b/usual/spinlock.c
@@ -39,7 +39,7 @@ void spin_lock_acquire(SpinLock *lock) {
     }
 
 #ifdef WIN32
-    while (InterlockedCompareExchangePointer(&lock->count, 1, 0) != 0) {
+    while (InterlockedCompareExchange(&lock->count, 1, 0) != 0) {
         SwitchToThread();
     }
 #else

--- a/usual/spinlock.c
+++ b/usual/spinlock.c
@@ -1,55 +1,48 @@
 #include <usual/logging.h>
 #include <usual/spinlock.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
 
-#define SPIN_LOCK_UNLOCKED 0
-#define SPIN_LOCK_LOCKED 1
 #define SPIN_LOCK_INITIALIZED 1
 
 void spin_lock_init(SpinLock *lock) {
-#ifdef WIN32
-    InterlockedExchange(&lock->lock, SPIN_LOCK_UNLOCKED);
-#else
-    lock->lock = SPIN_LOCK_UNLOCKED;
-#endif
-    lock->owner = 0;
+    lock->lock_word = 0;
+    lock->count = 0;
     lock->initialized = SPIN_LOCK_INITIALIZED;
 }
 
 void spin_lock_acquire(SpinLock *lock) {
-    if (lock->initialized != SPIN_LOCK_INITIALIZED) 
+    if (lock->initialized != SPIN_LOCK_INITIALIZED)
         fatal("Attempt to acquire an uninitialized lock!");
 
-#ifdef WIN32
-    while (InterlockedCompareExchange(&lock->lock, SPIN_LOCK_LOCKED, SPIN_LOCK_UNLOCKED) != 0) {
-        SwitchToThread();
+    uintptr_t self = GET_THREAD_ID();
+
+    if (lock->lock_word == self) {
+        lock->count++;
+        return;
     }
-#else
-    while (!__sync_bool_compare_and_swap(&lock->lock, SPIN_LOCK_UNLOCKED, SPIN_LOCK_LOCKED)) {
+
+    while (!__sync_bool_compare_and_swap(&lock->lock_word, 0, self)) {
         sched_yield();
     }
-#endif
-    lock->owner = GET_THREAD_ID();
+
+    MEMORY_BARRIER();
+    lock->count = 1;
 }
 
 void spin_lock_release(SpinLock *lock) {
-    if (lock->initialized != SPIN_LOCK_INITIALIZED) 
+    if (lock->initialized != SPIN_LOCK_INITIALIZED)
         fatal("Attempt to acquire an uninitialized lock!");
 
-#ifdef WIN32
-    if (lock->owner != GET_THREAD_ID()) {
+    uintptr_t self = GET_THREAD_ID();
+
+    if (lock->lock_word != self) {
         fatal("Thread %lu tried to release a lock it does not own!", (unsigned long)GET_THREAD_ID());
     }
-#else
-    if (!pthread_equal(lock->owner, GET_THREAD_ID())) {
-        fatal("Thread %lu tried to release a lock it does not own!", (unsigned long)GET_THREAD_ID());
+
+    if (--lock->count == 0) {
+        MEMORY_BARRIER();
+        lock->lock_word = 0;
     }
-#endif
-
-    lock->owner = 0;
-
-#ifdef WIN32
-    InterlockedExchange(&lock->lock, SPIN_LOCK_UNLOCKED);
-#else
-    __sync_bool_compare_and_swap(&lock->lock, SPIN_LOCK_LOCKED, SPIN_LOCK_UNLOCKED);
-#endif
 }

--- a/usual/spinlock.c
+++ b/usual/spinlock.c
@@ -27,7 +27,6 @@ void spin_lock_acquire(SpinLock *lock) {
         SwitchToThread();
     }
 #else
-    #include <sched.h>
     while (!__sync_bool_compare_and_swap(&lock->lock_word, 0, self)) {
         sched_yield();
     }

--- a/usual/spinlock.c
+++ b/usual/spinlock.c
@@ -10,10 +10,12 @@ void spin_lock_init(SpinLock *lock) {
 }
 
 void spin_lock_acquire(SpinLock *lock) {
+    uintptr_t self;
+
     if (lock->initialized != SPIN_LOCK_INITIALIZED)
         fatal("Attempt to acquire an uninitialized lock!");
 
-    uintptr_t self = GET_THREAD_ID();
+    self = GET_THREAD_ID();
 
     if (lock->lock_word == self) {
         lock->count++;
@@ -35,10 +37,12 @@ void spin_lock_acquire(SpinLock *lock) {
 }
 
 void spin_lock_release(SpinLock *lock) {
+    uintptr_t self;
+
     if (lock->initialized != SPIN_LOCK_INITIALIZED)
         fatal("Attempt to release an uninitialized lock!");
 
-    uintptr_t self = GET_THREAD_ID();
+    self = GET_THREAD_ID();
 
     if (lock->lock_word != self) {
         fatal("Thread %lu tried to release a lock it does not own!", (unsigned long)self);

--- a/usual/spinlock.c
+++ b/usual/spinlock.c
@@ -27,6 +27,7 @@ void spin_lock_acquire(SpinLock *lock) {
         SwitchToThread();
     }
 #else
+    #include <sched.h>
     while (!__sync_bool_compare_and_swap(&lock->lock_word, 0, self)) {
         sched_yield();
     }

--- a/usual/spinlock.c
+++ b/usual/spinlock.c
@@ -7,14 +7,14 @@
 #define SPIN_LOCK_INITIALIZED 1
 
 bool spin_lock_owns(SpinLock *lock){
-    if (lock->initialized != SPIN_LOCK_INITIALIZED)
-        fatal("Attempt to check an uninitialized lock!");
-    
     #ifdef WIN32
         volatile DWORD self; 
     #else
         volatile pthread_t self;
     #endif
+
+    if (lock->initialized != SPIN_LOCK_INITIALIZED)
+        fatal("Attempt to check an uninitialized lock!");
     
     self = GET_THREAD_ID();
 
@@ -22,7 +22,7 @@ bool spin_lock_owns(SpinLock *lock){
 }
 
 void spin_lock_init(SpinLock *lock) {
-    memset(&lock->lock_word, 0, sizeof(lock->lock_word));
+    memset((void*)&(lock->lock_word), 0, sizeof(lock->lock_word));
     lock->count = 0;
     lock->initialized = SPIN_LOCK_INITIALIZED;
 }

--- a/usual/spinlock.c
+++ b/usual/spinlock.c
@@ -25,6 +25,7 @@ void spin_lock_init(SpinLock *lock) {
     memset((void*)&(lock->lock_word), 0, sizeof(lock->lock_word));
     lock->count = 0;
     lock->initialized = SPIN_LOCK_INITIALIZED;
+    lock->enable_recursive = false;
 }
 
 void spin_lock_acquire(SpinLock *lock) {
@@ -33,7 +34,7 @@ void spin_lock_acquire(SpinLock *lock) {
         fatal("Attempt to acquire an uninitialized lock!");
 
 
-    if (spin_lock_owns(lock)) {
+    if (lock->enable_recursive && spin_lock_owns(lock)) {
         lock->count++;
         return;
     }
@@ -69,4 +70,9 @@ void spin_lock_release(SpinLock *lock) {
     RESET_LOCK_WORD(lock->lock_word);
     MEMORY_BARRIER();
     lock->count = 0;
+}
+
+
+void set_recursive(SpinLock *lock, bool recursive){
+    lock->enable_recursive = recursive;
 }

--- a/usual/spinlock.h
+++ b/usual/spinlock.h
@@ -21,11 +21,12 @@
 
 typedef struct {
 #ifdef WIN32
+    volatile LONG count;
     volatile DWORD lock_word;       // 0 = unlocked, otherwise holds thread ID
 #else
+    volatile int count;             // recursive depth
     volatile pthread_t lock_word;
 #endif
-    volatile int count;             // recursive depth
     int initialized;
 } SpinLock;
 

--- a/usual/spinlock.h
+++ b/usual/spinlock.h
@@ -1,6 +1,8 @@
 #ifndef _SPIN_LOCK_H_
 #define _SPIN_LOCK_H_
 
+#include <string.h>
+
 #ifdef WIN32
 #   include <windows.h>
 #   define GET_THREAD_ID() ((uintptr_t)GetCurrentThreadId()) 

--- a/usual/spinlock.h
+++ b/usual/spinlock.h
@@ -14,7 +14,7 @@
 
 typedef struct {
     volatile uintptr_t lock_word;  // 0 = unlocked, otherwise holds thread ID
-    int count;                     // recursive depth
+    volatile int count;            // recursive depth
     int initialized;
 } SpinLock;
 

--- a/usual/spinlock.h
+++ b/usual/spinlock.h
@@ -21,29 +21,10 @@
 #   define MEMORY_BARRIER() __sync_synchronize()
 
 #else
-#   include <sched.h>
 #   include <unistd.h>
-#   include <sys/types.h>
-#   include <sys/syscall.h>
-#   if defined(SYS_gettid)
-        static inline uintptr_t _linux_tid(void)
-        {
-            return (uintptr_t)syscall(SYS_gettid);
-        }
-#       define GET_THREAD_ID() _linux_tid()
-#   else        /* very old BSDs / exotic libc */
-#       include <pthread.h>
-        static inline uintptr_t _fallback_tid(void)
-        {
-            pthread_t self = pthread_self();
-            uintptr_t id = 0;
-            memcpy(&id, &self, sizeof(id));
-            return id;
-        }
-#       define GET_THREAD_ID() _fallback_tid()
-#   endif
+#   define GET_THREAD_ID() gettid()
 #   define MEMORY_BARRIER() __sync_synchronize()
-#endif /* platform switch */
+#endif
 
 typedef struct {
     volatile uintptr_t lock_word;  // 0 = unlocked, otherwise holds thread ID

--- a/usual/spinlock.h
+++ b/usual/spinlock.h
@@ -21,18 +21,20 @@
 
 typedef struct {
 #ifdef WIN32
-    volatile LONG count;
     volatile DWORD lock_word;       // 0 = unlocked, otherwise holds thread ID
+    volatile LONG count;
 #else
-    volatile int count;             // recursive depth
     volatile pthread_t lock_word;
+    volatile int count;             // recursive depth
 #endif
     int initialized;
+    bool enable_recursive;
 } SpinLock;
 
 bool spin_lock_owns(SpinLock *lock);
 void spin_lock_init(SpinLock *lock);
 void spin_lock_acquire(SpinLock *lock);
 void spin_lock_release(SpinLock *lock);
+void set_recursive(SpinLock *lock, bool recursive);
 
 #endif /* _SPIN_LOCK_H_ */

--- a/usual/spinlock.h
+++ b/usual/spinlock.h
@@ -34,7 +34,9 @@
         static inline uintptr_t _fallback_tid(void)
         {
             pthread_t self = pthread_self();
-            return (uintptr_t)(void *)&self;   /* unique for lifetime */
+            uintptr_t id = 0;
+            memcpy(&id, &self, sizeof(id));
+            return id;
         }
 #       define GET_THREAD_ID() _fallback_tid()
 #   endif

--- a/usual/spinlock.h
+++ b/usual/spinlock.h
@@ -8,7 +8,7 @@
 #   define GET_THREAD_ID() ((uintptr_t)GetCurrentThreadId()) 
 #   define MEMORY_BARRIER() MemoryBarrier()
 
-#elif HAVE_PTHREAD_THREADID_NP
+#elif defined(HAVE_PTHREAD_THREADID_NP) && HAVE_PTHREAD_THREADID_NP
 #   include <pthread.h>
     static inline uintptr_t _pthread_tid(void)
     {

--- a/usual/spinlock.h
+++ b/usual/spinlock.h
@@ -2,15 +2,44 @@
 #define _SPIN_LOCK_H_
 
 #ifdef WIN32
-    #include <windows.h>
-    #define GET_THREAD_ID() ((uintptr_t)GetCurrentThreadId())
-    #define MEMORY_BARRIER() MemoryBarrier()
+#   include <windows.h>
+#   define GET_THREAD_ID() ((uintptr_t)GetCurrentThreadId()) 
+#   define MEMORY_BARRIER() MemoryBarrier()
+
+#elif defined(__APPLE__)
+#   include <pthread.h>
+    static inline uintptr_t _darwin_tid(void)
+    {
+        uint64_t tid;
+        /* always succeeds for current thread */
+        (void)pthread_threadid_np(NULL, &tid);
+        return (uintptr_t)tid;
+    }
+#   define GET_THREAD_ID() _darwin_tid()
+#   define MEMORY_BARRIER() __sync_synchronize()
+
 #else
-    #include <usual/pthread.h>
-    #include <sched.h>
-    #define GET_THREAD_ID() ((uintptr_t)pthread_self())
-    #define MEMORY_BARRIER() __sync_synchronize()
-#endif
+#   include <sched.h>
+#   include <unistd.h>
+#   include <sys/types.h>
+#   include <sys/syscall.h>
+#   if defined(SYS_gettid)
+        static inline uintptr_t _linux_tid(void)
+        {
+            return (uintptr_t)syscall(SYS_gettid);
+        }
+#       define GET_THREAD_ID() _linux_tid()
+#   else        /* very old BSDs / exotic libc */
+#       include <pthread.h>
+        static inline uintptr_t _fallback_tid(void)
+        {
+            pthread_t self = pthread_self();
+            return (uintptr_t)(void *)&self;   /* unique for lifetime */
+        }
+#       define GET_THREAD_ID() _fallback_tid()
+#   endif
+#   define MEMORY_BARRIER() __sync_synchronize()
+#endif /* platform switch */
 
 typedef struct {
     volatile uintptr_t lock_word;  // 0 = unlocked, otherwise holds thread ID

--- a/usual/spinlock.h
+++ b/usual/spinlock.h
@@ -8,16 +8,16 @@
 #   define GET_THREAD_ID() ((uintptr_t)GetCurrentThreadId()) 
 #   define MEMORY_BARRIER() MemoryBarrier()
 
-#elif defined(__APPLE__)
+#elif HAVE_PTHREAD_THREADID_NP
 #   include <pthread.h>
-    static inline uintptr_t _darwin_tid(void)
+    static inline uintptr_t _pthread_tid(void)
     {
         uint64_t tid;
         /* always succeeds for current thread */
         (void)pthread_threadid_np(NULL, &tid);
         return (uintptr_t)tid;
     }
-#   define GET_THREAD_ID() _darwin_tid()
+#   define GET_THREAD_ID() _pthread_tid()
 #   define MEMORY_BARRIER() __sync_synchronize()
 
 #else

--- a/usual/spinlock.h
+++ b/usual/spinlock.h
@@ -1,8 +1,6 @@
 #ifndef _SPIN_LOCK_H_
 #define _SPIN_LOCK_H_
 
-#include <stdint.h>
-
 #ifdef WIN32
     #include <windows.h>
     #define GET_THREAD_ID() ((uintptr_t)GetCurrentThreadId())

--- a/usual/spinlock.h
+++ b/usual/spinlock.h
@@ -1,22 +1,22 @@
 #ifndef _SPIN_LOCK_H_
 #define _SPIN_LOCK_H_
 
+#include <stdint.h>
+
 #ifdef WIN32
     #include <windows.h>
-    #define ATOMIC_INT LONG
-    #define THREAD_ID DWORD
-    #define GET_THREAD_ID() GetCurrentThreadId()
+    #define GET_THREAD_ID() ((uintptr_t)GetCurrentThreadId())
+    #define MEMORY_BARRIER() MemoryBarrier()
 #else
-    #include <sched.h>
     #include <usual/pthread.h>
-    #define ATOMIC_INT int
-    #define THREAD_ID pthread_t
-    #define GET_THREAD_ID() pthread_self()
+    #include <sched.h>
+    #define GET_THREAD_ID() ((uintptr_t)pthread_self())
+    #define MEMORY_BARRIER() __sync_synchronize()
 #endif
 
 typedef struct {
-    ATOMIC_INT lock;
-    THREAD_ID owner;
+    volatile uintptr_t lock_word;  // 0 = unlocked, otherwise holds thread ID
+    int count;                     // recursive depth
     int initialized;
 } SpinLock;
 

--- a/usual/statlist_ts.h
+++ b/usual/statlist_ts.h
@@ -15,9 +15,10 @@ struct ThreadSafeStatList {
 };
 
 /** Initialize ThreadSafeStatList head */
-static inline void thread_safe_statlist_init(struct ThreadSafeStatList *list, const char *name) {
+static inline void thread_safe_statlist_init(struct ThreadSafeStatList *list, const char *name, bool enable_recursive_lock) {
     statlist_init(&list->list, name);
     spin_lock_init(&list->lock);
+    set_recursive(&list->lock, enable_recursive_lock);
 }
 
 /** Add to the start of the list */


### PR DESCRIPTION
This PR introduces a recursive spinlock based on a single atomic `lock_word` that stores the owning thread's ID. The motivation is to simplify lock usage in PgBouncer, where deep call stacks and complex control flows make it difficult to manually manage lock acquisition order.

Details:
- `lock_word` holds the thread ID; `0` means unlocked.
- Recursive re-acquisition is allowed if the current thread already owns the lock.

Coworker: @GuanqunYang193 