### PR TITLE
CI: Remove legacy MINGW32 environment

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -157,8 +157,6 @@ task:
   matrix:
     - env:
         MSYSTEM: MINGW64
-    - env:
-        MSYSTEM: MINGW32
   setup_script:
     - choco install -y --no-progress msys2
     - sh -l -c "pacman --noconfirm -S --needed base-devel ${MINGW_PACKAGE_PREFIX}-toolchain ${MINGW_PACKAGE_PREFIX}-libevent autoconf automake libtool"


### PR DESCRIPTION
MINGW32 is listed on https://www.msys2.org/docs/environments/ as a "legacy environment", and it doesn't appear to be maintained anymore (e.g., some packages are missing), so remove it from CI.  (pgbouncer had already removed it from its CI some time ago.)

closes #74