### PR TITLE
Add support for configuring ALPN for TLS servers

### DIFF
--- a/usual/tls/tls.h
+++ b/usual/tls/tls.h
@@ -100,6 +100,9 @@ int tls_config_set_ocsp_stapling_file(struct tls_config *_config, const char *_b
 int tls_config_set_ocsp_stapling_mem(struct tls_config *_config, const uint8_t *_blob, size_t _len);
 void tls_config_set_protocols(struct tls_config *_config, uint32_t _protocols);
 void tls_config_set_verify_depth(struct tls_config *_config, int _verify_depth);
+void tls_config_set_alpn_protocols(struct tls_config *_config,
+				   const unsigned char *_protocols,
+				   size_t _protocols_len);
 
 void tls_config_prefer_ciphers_client(struct tls_config *_config);
 void tls_config_prefer_ciphers_server(struct tls_config *_config);

--- a/usual/tls/tls_config.c
+++ b/usual/tls/tls_config.c
@@ -107,6 +107,27 @@ static void tls_keypair_free(struct tls_keypair *keypair)
 	free(keypair);
 }
 
+struct tls_alpn_config *tls_alpn_config_new(void) {
+	return calloc(1, sizeof(struct tls_alpn_config));
+}
+
+void tls_alpn_config_set_protocols(struct tls_config *config,
+				   const unsigned char *protocols,
+				   size_t len)
+{
+	config->alpn_config->protocols = protocols;
+	config->alpn_config->protocols_len = len;
+}
+
+static void tls_alpn_config_free(struct tls_alpn_config *alpn_config)
+{
+	if (alpn_config == NULL)
+		return;
+
+	free(alpn_config);
+}
+
+
 struct tls_config *tls_config_new(void)
 {
 	struct tls_config *config;
@@ -115,6 +136,9 @@ struct tls_config *tls_config_new(void)
 		return (NULL);
 
 	if ((config->keypair = tls_keypair_new()) == NULL)
+		goto err;
+
+	if ((config->alpn_config = tls_alpn_config_new()) == NULL)
 		goto err;
 
 	/*
@@ -154,6 +178,8 @@ void tls_config_free(struct tls_config *config)
 		nkp = kp->next;
 		tls_keypair_free(kp);
 	}
+
+	tls_alpn_config_free((config->alpn_config));
 
 	free(config->error.msg);
 
@@ -397,6 +423,14 @@ void tls_config_set_protocols(struct tls_config *config, uint32_t protocols)
 void tls_config_set_verify_depth(struct tls_config *config, int verify_depth)
 {
 	config->verify_depth = verify_depth;
+}
+
+
+void tls_config_set_alpn_protocols(struct tls_config *config,
+				   const unsigned char *protocols,
+				   size_t len)
+{
+	tls_alpn_config_set_protocols(config, protocols, len);
 }
 
 void tls_config_prefer_ciphers_client(struct tls_config *config)

--- a/usual/tls/tls_internal.h
+++ b/usual/tls/tls_internal.h
@@ -46,6 +46,11 @@ struct tls_keypair {
 	size_t key_len;
 };
 
+struct tls_alpn_config {
+	const unsigned char *protocols;
+	size_t protocols_len;
+};
+
 struct tls_config {
 	struct tls_error error;
 
@@ -67,6 +72,7 @@ struct tls_config {
 	int verify_depth;
 	int verify_name;
 	int verify_time;
+	struct tls_alpn_config *alpn_config;
 };
 
 struct tls_conninfo {
@@ -179,5 +185,10 @@ int asn1_time_parse(const char *, size_t, struct tm *, int);
 struct tls_keypair * tls_keypair_new(void);
 int tls_keypair_set_cert_file(struct tls_keypair *keypair, const char *cert_file);
 bool tls_keypair_list_equal(struct tls_keypair *tkp1, struct tls_keypair *tkp2);
+
+struct tls_alpn_config * tls_alpn_config_new(void);
+void tls_alpn_config_set_protocols(struct tls_config *config,
+				   const unsigned char *protocols,
+				   size_t len);
 
 #endif /* HEADER_TLS_INTERNAL_H */

--- a/usual/tls/tls_server.c
+++ b/usual/tls/tls_server.c
@@ -50,6 +50,49 @@ struct tls *tls_server_conn(struct tls *ctx)
 	return (conn_ctx);
 }
 
+int
+alpn_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
+	const unsigned char *in, unsigned int inlen, void *userdata);
+
+/*
+ * Server callback for ALPN negotiation.
+ *
+ * The protocol strings should be registered at:
+ * https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
+ *
+ * c.f. https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_alpn_select_cb.html
+ */
+int
+alpn_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
+	const unsigned char *in, unsigned int inlen, void *userdata)
+{
+	int retval;
+	struct tls_alpn_config *data;
+	size_t protocols_len;
+
+	Assert(userdata != NULL);
+	Assert(out != NULL);
+	Assert(outlen != NULL);
+	Assert(in != NULL);
+
+	data = (struct tls_alpn_config*) userdata;
+	protocols_len = data->protocols_len;
+	retval = SSL_select_next_proto((unsigned char **) out, outlen,
+				       data->protocols, protocols_len,
+				       in, inlen);
+
+	if (*out == NULL || *outlen > protocols_len || *outlen <= 0)
+		return SSL_TLSEXT_ERR_NOACK;
+	if (retval == OPENSSL_NPN_NO_OVERLAP)
+		return SSL_TLSEXT_ERR_NOACK;
+	if (retval != OPENSSL_NPN_NEGOTIATED)
+		return SSL_TLSEXT_ERR_NOACK;
+
+	return SSL_TLSEXT_ERR_OK;
+}
+
+
+
 int tls_configure_server(struct tls *ctx)
 {
 	EC_KEY *ecdh_key;
@@ -59,6 +102,9 @@ int tls_configure_server(struct tls *ctx)
 	if ((ctx->ssl_ctx = SSL_CTX_new(SSLv23_server_method())) == NULL) {
 		tls_set_errorx(ctx, "ssl context failure");
 		goto err;
+	}
+	if (ctx->config->alpn_config) {
+		SSL_CTX_set_alpn_select_cb(ctx->ssl_ctx, alpn_cb, (void *)ctx->config->alpn_config);
 	}
 
 	if (tls_configure_ssl(ctx) != 0)


### PR DESCRIPTION
This commit adds support for optionally configuring Application-Layer Protocol Negotation (ALPN) for TLS servers [1]. If any protocols have been configured, the TLS server will invoke a callback configured with SSL_CTX_set_alpn_select_cb [2]. The callback uses SSL_select_next_proto, which implements the standard protocol selection.

If no ALPN protocls have been configured, the TLS server does not register a callback and skips ALPN entirely.

Related to https://github.com/pgbouncer/pgbouncer/issues/1203.

This code is partly based on the Postgres implementation of the ALPN callback function. See [3].

[1]: https://datatracker.ietf.org/doc/html/rfc7301
[2]: https://docs.openssl.org/3.0/man3/SSL_CTX_set_alpn_select_cb/
[3]: https://github.com/postgres/postgres/blob/3683af617044d271ab7486d43d06f9689ed4961d/src/backend/libpq/be-secure-openssl.c#L1330-L1370